### PR TITLE
Support for single language code tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+0.4.6 / 2020/09/29
+==================
+- Improved custom code renderer to support default markdown fenced code block with explicitly specified language.
+
 0.4.5 / 2020/09/09
+==================
 - Fixed custom code renderer to support the use case of rendering code tabs.
 
 0.4.4 / 2020/09/01

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "rm -rf ./build && babel src --out-dir build && cp src/*.json build",
     "build-doc": "npm run clean && npm run build && node ./node_modules/jsdoc/jsdoc.js --package ./package.json -c ./jsdoc/conf.json -d docs",
+    "build-local-dev": "npm run build && cp package.json build && pushd build/ && npm i && popd",
     "test": "npm run build && mocha --timeout 5000 --require @babel/register --recursive",
     "test-cov": "npm run build && babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/mocha/bin/_mocha -- --reporter dot",
     "prepublishOnly": "test $RUNNING_FROM_SCRIPT || (echo \"You must use publish.sh instead of 'npm publish' directly!\"; exit 1)",

--- a/src/marked.js
+++ b/src/marked.js
@@ -13,8 +13,8 @@ import { customHeadingRenderer } from './markdown_renderers';
  */
 const LANGAUGE_TO_TAB_TITLE = {
     js: 'Node.JS',
-    javascript: 'Node.JS',
-    nodejs: 'Node.JS',
+    javascript: 'Node.js',
+    nodejs: 'Node.js',
     bash: 'Bash',
     curl: 'cURL',
     dockerfile: 'Dockerfile',
@@ -22,8 +22,8 @@ const LANGAUGE_TO_TAB_TITLE = {
     json: 'JSON',
     xml: 'XML',
     python: 'Python',
-    python2: 'Python3',
-    python3: 'Python3',
+    python2: 'Python 2',
+    python3: 'Python 3',
     yml: 'YAML',
     yaml: 'YAML',
 };

--- a/test/marked.js
+++ b/test/marked.js
@@ -10,7 +10,7 @@ const MARKDOWN_UNDER_TEST = `
 
 ## Code block with tabs
 \`\`\`marked-tabs
-<marked-tab header="NodeJS" lang="javascript">
+<marked-tab header="Node.js" lang="javascript">
 console.log('Some JS code');
 </marked-tab>
 
@@ -22,7 +22,7 @@ if count >= 1:
 print('Some python code on next line');
 </marked-tab>
 
-<marked-tab header="Curl" lang="bash">
+<marked-tab header="Bash" lang="bash">
 echo "Some bash code"
 </marked-tab>
 \`\`\`
@@ -32,12 +32,18 @@ echo "Some bash code"
 console.log('Your standard javascript code block')
 \`\`\`
 
+\`\`\`
+console.log('Fenced block with no language')
+\`\`\`
+
+    console.log('Tab indented block')
+
 ## Second block with tabs
 \`\`\`marked-tabs
-<marked-tab header="NodeJS" lang="javascript">
+<marked-tab header="Custom title" lang="javascript">
 console.log('Some JS code 2');
 </marked-tab>
-<marked-tab header="Curl" lang="bash">
+<marked-tab header="Bash" lang="bash">
 echo "Some bash code 2"
 </marked-tab>
 \`\`\`
@@ -49,9 +55,10 @@ This is footer text.
 const EXPECTED_HTML =   '\n' +
 '            <h1 id="title">Title</h1>\n' +
 '            <h2 id="code-block-with-tabs">Code block with tabs</h2>[apify-code-tabs]0[/apify-code-tabs]\n' +
-'            <h2 id="code-block-without-tabs">Code block without tabs</h2><pre><code class="language-javascript">console.log(&#39;Your standard javascript code block&#39;)</code></pre>\n' +
+'            <h2 id="code-block-without-tabs">Code block without tabs</h2>[apify-code-tabs]1[/apify-code-tabs]<pre><code>console.log(&#39;Fenced block with no language&#39;)</code></pre>\n' +
+'<pre><code>console.log(&#39;Tab indented block&#39;)</code></pre>\n' +
 '\n' +
-'            <h2 id="second-block-with-tabs">Second block with tabs</h2>[apify-code-tabs]1[/apify-code-tabs]\n' +
+'            <h2 id="second-block-with-tabs">Second block with tabs</h2>[apify-code-tabs]2[/apify-code-tabs]\n' +
 '            <h2 id="footer">Footer</h2><p>This is footer text.</p>\n';
 
 describe('apifyMarked custom renderer works', () => {
@@ -62,20 +69,23 @@ describe('apifyMarked custom renderer works', () => {
         expect(codeTabsObjectPerIndex).to.eql(
             {
                 '0': {
-                  NodeJS: { language: 'javascript', code: "console.log('Some JS code');" },
-                  Python: {
-                    language: 'python',
-                    code: "print('Some python code');\n" +
-                      'count = 1\n' +
-                      'if count >= 1:\n' +
-                      "    print('Some intended python code');\n" +
-                      "print('Some python code on next line');"
-                  },
-                  Curl: { language: 'bash', code: 'echo "Some bash code"' }
+                    'Node.js': { language: 'javascript', code: "console.log('Some JS code');" },
+                    Python: {
+                        language: 'python',
+                        code: "print('Some python code');\n" +
+                        'count = 1\n' +
+                        'if count >= 1:\n' +
+                        "    print('Some intended python code');\n" +
+                        "print('Some python code on next line');"
+                    },
+                    'Bash': { language: 'bash', code: 'echo "Some bash code"' }
                 },
                 '1': {
-                  NodeJS: { language: 'javascript', code: "console.log('Some JS code 2');" },
-                  Curl: { language: 'bash', code: 'echo "Some bash code 2"' }
+                    'Node.js': { language: 'javascript', code: "console.log('Your standard javascript code block')" },
+                },
+                '2': {
+                    'Custom title': { language: 'javascript', code: "console.log('Some JS code 2');" },
+                    Bash: { language: 'bash', code: 'echo "Some bash code 2"' }
                 }
             }
         );


### PR DESCRIPTION
Improved custom code renderer to support default markdown fenced code block with explicitly specified language.