### PR TITLE
Update function to convert relative image paths in READMEs to absolute paths to support more URL formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.5.7 / 2021/01/14
+==================
+- Updated function to convert relative image paths in git README files to absolute paths to support more URL formats
+
 0.5.6 / 2020/12/10
 ==================
 - Replaced `crypto` in favor of `create-hmac` in ImageProxyClient so it can be used in browsers as well

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [

--- a/src/git.js
+++ b/src/git.js
@@ -1,7 +1,7 @@
 import gitUrlParse from 'git-url-parse';
 
 /**
- * This replaces all relative image paths (starting with './') in markdown readme
+ * This replaces all relative image paths in markdown readme
  * by appropriate absolute paths so they can be correctly rendered on the website.
  * At the moment, the conversion works for 3 major repo systems, namely Github, Gitlab and Bitbucket and
  * also works if the user opted to use custom branch for deploying their actor to Apify.
@@ -24,11 +24,24 @@ export const convertRelativeImagePathsToAbsoluteInReadme = ({ readme, gitRepoUrl
     // Prior to that, all default branches were 'master', hence we default to that as a backup.
     const branchName = parsedRepoUrl.hash || gitBranchName || 'master';
 
+    // We want to replace relative paths (all paths which are not absolute, so anything not starting with http://, https://, ftp:// or data:)
+    // with absolute paths, which is done by these fancy regular expressions
+
     // Images in markdown have syntax ![alt text](image url)
+    // (!\[.*?\])\( matches the start of the image code
+    // (?!(?:(?:https?|ftp):\/\/|data:)) lookahead matches if the next part of the string is not http://, https://, ftp:// or data:
+    // (?:\.?\/) matches the starting ./ or / in a relative or root-relative URL, which can be ignored when converting to absolute link
+    // (.*?) matches the actual relative URL
+    // \) matches the end parenthesis
     const relativeImageMarkdownRegex = /(!\[.*?\])\((?!(?:(?:https?|ftp):\/\/|data:))(?:\.?\/)?(.*?)\)/g;
 
     // HTML image references of type <img src="..." /> can be also embedded in markdown (e.g. in HTML table)
     // We provide 2 regular expression for cases where src attribute is wrapped in double or single quotes
+    // (<img.*?src=") or (<img.*?src=') matches the start of the image code
+    // (?!(?:(?:https?|ftp):\/\/|data:)) lookahead matches if the next part of the string is not http://, https://, ftp:// or data:
+    // (?:\.?\/) matches the starting ./ or / in a relative or root-relative URL, which can be ignored when converting to absolute link
+    // (.*?) matches the actual relative URL
+    // (".*?\/>) or ('.*?\/>) matches the end of the image code
     const relativeImageHtmlRegexWithDoubleQuotes = /(<img.*?src=")(?!(?:(?:https?|ftp):\/\/|data:))(?:\.?\/)?(.*?)(".*?\/>)/g;
     const relativeImageHtmlRegexWithSingleQuotes = /(<img.*?src=')(?!(?:(?:https?|ftp):\/\/|data:))(?:\.?\/)?(.*?)('.*?\/>)/g;
 

--- a/src/git.js
+++ b/src/git.js
@@ -25,12 +25,12 @@ export const convertRelativeImagePathsToAbsoluteInReadme = ({ readme, gitRepoUrl
     const branchName = parsedRepoUrl.hash || gitBranchName || 'master';
 
     // Images in markdown have syntax ![alt text](image url)
-    const relativeImageMarkdownRegex = /(!\[.*?\])\(\.\/(.*?)\)/g;
+    const relativeImageMarkdownRegex = /(!\[.*?\])\((?!(?:(?:https?|ftp):\/\/|data:))(?:\.?\/)?(.*?)\)/g;
 
     // HTML image references of type <img src="..." /> can be also embedded in markdown (e.g. in HTML table)
     // We provide 2 regular expression for cases where src attribute is wrapped in double or single quotes
-    const relativeImageHtmlRegexWithDoubleQuotes = /(<img.*?src=")\.\/(.*?)(".*?\/>)/g;
-    const relativeImageHtmlRegexWithSingleQuotes = /(<img.*?src=')\.\/(.*?)('.*?\/>)/g;
+    const relativeImageHtmlRegexWithDoubleQuotes = /(<img.*?src=")(?!(?:(?:https?|ftp):\/\/|data:))(?:\.?\/)?(.*?)(".*?\/>)/g;
+    const relativeImageHtmlRegexWithSingleQuotes = /(<img.*?src=')(?!(?:(?:https?|ftp):\/\/|data:))(?:\.?\/)?(.*?)('.*?\/>)/g;
 
     let urlPrefix = null;
     if (parsedRepoUrl.resource === 'github.com') {

--- a/test/git.js
+++ b/test/git.js
@@ -5,6 +5,69 @@ import { expect } from 'chai';
 import { convertRelativeImagePathsToAbsoluteInReadme } from '../src/git';
 
 describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
+    it('works correctly for all forms of relative paths', () => {
+        const testMarkdown = `
+            # Heading
+            ![img1](/root/relative/path/to/img.jpg)
+            ![img2](./relative-path-to-img.jpg)
+            ![img3](relative-path-to-img.jpg)
+            <img src='/root/relative/path/to/img.jpg' />
+            <img src='./relative-path-to-img.jpg' />
+            <img src='relative-path-to-img.jpg' />
+            <img src="/root/relative/path/to/img.jpg" />
+            <img src="./relative-path-to-img.jpg" />
+            <img src="relative-path-to-img.jpg" />
+        `;
+
+        const expectedResult = `
+            # Heading
+            ![img1](https://raw.githubusercontent.com/apify/test-repo/master/root/relative/path/to/img.jpg)
+            ![img2](https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg)
+            ![img3](https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg)
+            <img src='https://raw.githubusercontent.com/apify/test-repo/master/root/relative/path/to/img.jpg' />
+            <img src='https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg' />
+            <img src='https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg' />
+            <img src="https://raw.githubusercontent.com/apify/test-repo/master/root/relative/path/to/img.jpg" />
+            <img src="https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg" />
+            <img src="https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg" />
+        `;
+
+        expect(convertRelativeImagePathsToAbsoluteInReadme({
+            readme: testMarkdown,
+            gitRepoUrl: 'git@github.com:apify/test-repo.git',
+        })).to.eql(expectedResult)
+    });
+
+    it('does not convert absolute paths', () => {
+        const testMarkdown = `
+            # Heading
+            ![img1](https://apify.com/path/to/img.jpg)
+            ![img2](http://apify.com/path/to/img.jpg)
+            ![img3](ftp://apify.com/path/to/img.jpg)
+            <img src='https://apify.com/path/to/img.jpg' />
+            <img src='http://apify.com/path/to/img.jpg' />
+            <img src='ftp://apify.com/path/to/img.jpg' />
+        `;
+
+        expect(convertRelativeImagePathsToAbsoluteInReadme({
+            readme: testMarkdown,
+            gitRepoUrl: 'git@github.com:apify/test-repo.git',
+        })).to.eql(testMarkdown)
+    });
+
+    it('does not convert Base64 encoded images', () => {
+        const testMarkdown = `
+            # Heading
+            ![img1](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=)
+            <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=' />
+        `;
+
+        expect(convertRelativeImagePathsToAbsoluteInReadme({
+            readme: testMarkdown,
+            gitRepoUrl: 'git@github.com:apify/test-repo.git',
+        })).to.eql(testMarkdown)
+    });
+
     it('works correctly for Github repo with explicit branch name', () => {
         const testMarkdown = `
             # Heading
@@ -97,7 +160,7 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
         })).to.eql(expectedResult)
     });
 
-    it('works correctly for Github repo with explicit branch name and <img src=... /> tags', () => {
+    it('works correctly for Github repo without explicit branch name and <img src=... /> tags', () => {
         const testMarkdown = `
             # Heading
             ![img1](http://www.apify-awesome-test-image.com)
@@ -124,10 +187,7 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
             <img alt="Some alt text" src="https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg" />
             <img alt="Some alt text" src="https://raw.githubusercontent.com/apify/test-repo/master/relative-path-to-img.jpg" width="500"/>
         `;
-        console.log(convertRelativeImagePathsToAbsoluteInReadme({
-            readme: testMarkdown,
-            gitRepoUrl: 'git@github.com:apify/test-repo.git',
-        }));
+
         expect(convertRelativeImagePathsToAbsoluteInReadme({
             readme: testMarkdown,
             gitRepoUrl: 'git@github.com:apify/test-repo.git',
@@ -140,6 +200,7 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
             ![img1](http://www.apify-awesome-test-image.com)
             ![img2](./relative-path-to-img.jpg)
         `;
+
         expect(convertRelativeImagePathsToAbsoluteInReadme({
             readme: testMarkdown,
             gitRepoUrl: 'git@some-unknown-git-site.com:apify/test-repo.git',

--- a/test/git.js
+++ b/test/git.js
@@ -55,6 +55,19 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
         })).to.eql(testMarkdown)
     });
 
+    it('does not convert <img> tags with mismatched quotes', () => {
+        const testMarkdown = `
+            # Heading
+            <img src='path/to/img.jpg" />
+            <img src="path/to/img.jpg' />
+        `;
+
+        expect(convertRelativeImagePathsToAbsoluteInReadme({
+            readme: testMarkdown,
+            gitRepoUrl: 'git@github.com:apify/test-repo.git',
+        })).to.eql(testMarkdown)
+    });
+
     it('does not convert Base64 encoded images', () => {
         const testMarkdown = `
             # Heading


### PR DESCRIPTION
I updated the function for converting relative paths to absolute paths in READMEs to fix issues with rendering some public actor READMEs.
 
Now it converts all relative URLs, like:
- `./path/to/image.jpg`
- `/root/relative/path/to/image.jpg`
- `relative/path/to/image.jpg`

It also makes sure not to convert Base64-encoded images.