### PR TITLE
Rework custom heading renderer in apify-marked, update marked to fix vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.6.0 / 2021/02/11
+==================
+- Reworked custom heading renderer in `apifyMarked`
+- Updated `marked` to 2.0.0 because of https://github.com/advisories/GHSA-4r62-v4vq-hr96
+
 0.5.9 / 2021/02/04
 ==================
 - Added `PROXY_STATUS_URL` environment variable to the constants file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [
@@ -44,7 +44,7 @@
     "create-hmac": "^1.1.7",
     "git-url-parse": "^11.4.4",
     "is-buffer": "^2.0.5",
-    "marked": "^1.2.4",
+    "marked": "^2.0.0",
     "match-all": "^1.2.6",
     "moment": "^2.29.1",
     "request": "^2.88.0",

--- a/src/markdown_renderers.js
+++ b/src/markdown_renderers.js
@@ -1,29 +1,51 @@
-import log from './log';
+export const formatHeadingId = (headingId) => {
+    // Replace non-word characters with dashes
+    headingId = headingId.toLowerCase().trim().replace(/[^\w]+/g, '-');
+    // Replace multiple following dashes with one dash
+    headingId = headingId.replace(/[-]+/g, '-');
+    // Remove dashes at the beginning and end
+    headingId = headingId.replace(/^[-]+|[-]+$/g, '');
 
-function formatIdTag(idTag) {
-    // Get rid of whitespace and random characters
-    idTag = idTag.toLowerCase().trim().replace(/[^\w]+/g, '-');
-    // Remove dashes at the and end
-    idTag = idTag.replace(/^[-]+|[-]+$/g, '');
-    return idTag;
-}
+    return headingId;
+};
 
-export const customHeadingRenderer = (text, level, raw) => {
-    const idRegEx = /[^{}]+(?=})/g;
-    const idTags = text.match(idRegEx);
-    // If provided, format custom ID
-    let idTag = idTags && idTags.length ? formatIdTag(idTags[0]) : null;
-    // If no ID tag provided, generate from title
-    if (!idTag) idTag = formatIdTag(raw);
-    // If the custom ID is badly formatted, throw error
-    if (idTags && idTag !== idTags[0]) {
-        log.warning('apifyMarked: badly formatted heading ID passed to customHeadingRenderer', { id: idTags[0] });
+export const extractHeadingIdAndText = (text, raw) => {
+    // Check if there is a custom fragment link with the custom heading ID present in the heading
+    // The heading text already comes rendered from Markdown to HTML to the renderer, so we have to look for an <a> tag instead of the Markdown source
+    const parsingRegExp = new RegExp('<a href="#([^"]+)"></a>(.*)');
+    const regexMatch = text.match(parsingRegExp);
+
+    let headingId = '';
+    let headingText = '';
+
+    if (regexMatch && regexMatch.length) {
+        // If there was a custom heading ID, format it to make sure it follows our heading structure
+        headingId = formatHeadingId(regexMatch[1]);
+        headingText = regexMatch[2].trim();
+    } else {
+        // If there was no custom heading ID, format the heading text into one
+        headingId = formatHeadingId(raw);
+        headingText = text.trim();
     }
+    return { headingId, headingText };
+};
 
-    const titleText = text.split('{')[0].trim();
+/**
+ * Renders headings by adding an ID to them, and adds a fragment link pointing to that ID (we use it to render a copy icon)
+ * Optionally parses a custom ID from the heading text
+ * So that:
+ *   ## Heading text
+ *     becomes
+ *   <h2 id="heading-text"><a href="#heading-text"></a>Heading text</h2>
+ * and
+ *   ### [](#custom-id) Heading text
+ *     becomes
+ *   <h3 id="custom-id"><a href="#custom-id"></a>Heading text</h3>
+*/
+export const customHeadingRenderer = (text, level, raw) => {
+    const { headingId, headingText } = extractHeadingIdAndText(text, raw);
 
     const headingToReturn = `
-            <h${level} id="${idTag}">${titleText}</h${level}>`;
-
+            <h${level} id="${headingId}"><a href="#${headingId}"></a>${headingText}</h${level}>`;
     return headingToReturn;
 };

--- a/src/marked.js
+++ b/src/marked.js
@@ -56,9 +56,9 @@ const codeTabObjectFromCodeTabMarkdown = (markdown) => {
  *
  * It parses the given markdown and treats some headings and code blocks in a custom way
  * -----------------------------------------------------------------------------------------------
- * 0. Heading with {custom-id} in text will have id="custom-id" property on reasulting <h...> tag.
+ * 0. Heading with [](#custom-id) before the text will have id="custom-id" property on reasulting <h...> tag.
  * E.g.
- * # Welcome to Apify {welcome-title-id}
+ * # [](#welcome-title-id) Welcome to Apify
  * is turned to
  * <h1 id="welcome-title-id">Welcome to Apify</h1>
  * -----------------------------------------------------------------------------------------------

--- a/test/markdown_renderers.js
+++ b/test/markdown_renderers.js
@@ -12,20 +12,20 @@ describe('apifyMarked custom renderer works', () => {
 
 
     it('uses the custom ID if provided', () => {
-        const renderedTitle = marked('# Welcome to Apify {welcome-title-id}', { renderer });
+        const renderedTitle = marked('# [](#welcome-title-id) Welcome to Apify', { renderer });
         expect(renderedTitle).to.equal(`
-            <h1 id="welcome-title-id">Welcome to Apify</h1>`);
+            <h1 id="welcome-title-id"><a href="#welcome-title-id"></a>Welcome to Apify</h1>`);
     });
 
     it('generates ID from text if no ID provided', () => {
         const renderedTitle = marked('## Welcome to Apify', { renderer });
         expect(renderedTitle).to.eql(`
-            <h2 id="welcome-to-apify">Welcome to Apify</h2>`);
+            <h2 id="welcome-to-apify"><a href="#welcome-to-apify"></a>Welcome to Apify</h2>`);
     });
 
-    it('trims whitespace, inserts dashes between words, converts to lowercase, removes punctuation and trailing dash', () => {
-        const renderedTitle = marked('# Welcome to Apify { #  .Welcome -title-id . - ? -}', { renderer });
-        expect(renderedTitle).to.eql(`
-            <h1 id="welcome-title-id">Welcome to Apify</h1>`);
+    it('converts to lowercase, removes punctuation, multiple continuous dashes and leading and trailing dash', () => {
+        const renderedTitle = marked('### [](#?--welCOme-title-.?id---) Welcome to Apify', { renderer });
+        expect(renderedTitle).to.equal(`
+            <h3 id="welcome-title-id"><a href="#welcome-title-id"></a>Welcome to Apify</h3>`);
     });
 });

--- a/test/marked.js
+++ b/test/marked.js
@@ -53,15 +53,15 @@ This is footer text.
 `;
 
 const EXPECTED_HTML =   '\n' +
-'            <h1 id="title">Title</h1>\n' +
-'            <h2 id="code-block-with-tabs">Code block with tabs</h2>[apify-code-tabs]0[/apify-code-tabs]\n' +
-'            <h2 id="code-block-without-tabs">Code block without tabs</h2>[apify-code-tabs]1[/apify-code-tabs]<pre><code>console.log(&#39;Fenced block with no language&#39;)\n' +
+'            <h1 id="title"><a href="#title"></a>Title</h1>\n' +
+'            <h2 id="code-block-with-tabs"><a href="#code-block-with-tabs"></a>Code block with tabs</h2>[apify-code-tabs]0[/apify-code-tabs]\n' +
+'            <h2 id="code-block-without-tabs"><a href="#code-block-without-tabs"></a>Code block without tabs</h2>[apify-code-tabs]1[/apify-code-tabs]<pre><code>console.log(&#39;Fenced block with no language&#39;)\n' +
 '</code></pre>\n' +
 '<pre><code>console.log(&#39;Tab indented block&#39;)\n' +
 '</code></pre>\n' +
 '\n' +
-'            <h2 id="second-block-with-tabs">Second block with tabs</h2>[apify-code-tabs]2[/apify-code-tabs]\n' +
-'            <h2 id="footer">Footer</h2><p>This is footer text.</p>\n';
+'            <h2 id="second-block-with-tabs"><a href="#second-block-with-tabs"></a>Second block with tabs</h2>[apify-code-tabs]2[/apify-code-tabs]\n' +
+'            <h2 id="footer"><a href="#footer"></a>Footer</h2><p>This is footer text.</p>\n';
 
 describe('apifyMarked custom renderer works', () => {
 


### PR DESCRIPTION
We're not using the current way to pass custom IDs to headings anywhere right now, because the markup in the required format renders badly if not using `apifyMarked`.

This PR reworks the way custom IDs are passed to this:
```md
 ### [](#custom-id) Heading text
````
becomes
````html
 <h3 id="custom-id"><a href="#custom-id"></a>Heading text</h3>
````

The link is rendered empty, so it takes no space, but in Docs we're using it to render the "Copy to clipboard" link and icon, and we had to add it everywhere manually up until now.

The `apifyMarked` renderer is not used anywhere but in Docs, so this should not break anything, but I'm releasing this as a breaking change just in case.