### PR TITLE
feat: add rudimentary typing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pids
 .idea
 yarn.lock
 package-lock.json
+types/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.7.2",
     "description": "Tools and constants shared across Apify projects.",
     "main": "build/index.js",
+    "types": "types/index.d.ts",
     "keywords": [
         "apify"
     ],
@@ -25,13 +26,13 @@
     },
     "homepage": "https://apify.com",
     "scripts": {
-        "build": "rm -rf ./build && babel src --out-dir build && cp src/*.json build",
+        "build": "rm -rf build types && babel src --out-dir build && cp src/*.json build && tsc ./src/*.js --allowJs --declaration --emitDeclarationOnly --declarationDir types --skipLibCheck",
         "build-doc": "npm run clean && npm run build && node ./node_modules/jsdoc/jsdoc.js --package ./package.json -c ./jsdoc/conf.json -d docs",
         "build-local-dev": "npm run build && cp package.json build && pushd build/ && npm i && popd",
         "test": "npm run build && mocha --timeout 5000 --require @babel/register --recursive",
         "test-cov": "npm run build && babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/mocha/bin/_mocha -- --reporter dot",
         "prepublishOnly": "(test $CI || (echo \"Publishing is reserved to CI!\"; exit 1))",
-        "clean": "rm -rf build && rm -rf docs",
+        "clean": "rm -rf build docs types",
         "lint": "npm run build && eslint src test",
         "lint:fix": "eslint src test --fix"
     },
@@ -72,6 +73,7 @@
         "mocha": "^7.2.0",
         "nock": "^13.0.7",
         "sinon": "^9.2.4",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.0",
+        "typescript": "^4.2.3"
     }
 }


### PR DESCRIPTION
This PR adds very basic automated typings to this module, as it is helpful (and needed) in order to complete the TS migration of https://github.com/apify/apify-storage-local-js (and any further modules).

It creates typings automatically on build by invoking the `tsc` compiler on the pre-babel-build JS and telling it to emit JUST declarations. I thought it'd be best if I inlined the options for now, as this makes for a simple setup that should be deploy-ready 😄 

*Note that yes, a LOT of the types are `any` due to lack of JSDocs, however they are enough for now*

CC: @pocesar @B4nan 