### PR TITLE
fix: properly export logger so TS works

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,17 @@
 {
-    "presets": [
-      ["@babel/preset-env", {
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
         "targets": {
           "node": "10.17.0"
         }
-      }]
-    ],
-    "plugins": [
-        "add-module-exports",
-        "@babel/plugin-proposal-object-rest-spread"
+      }
     ]
+  ],
+  "plugins": [
+    "add-module-exports",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-class-properties"
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,4 @@
 {
-    "extends": "@apify"
+    "extends": "@apify",
+    "parser": "@babel/eslint-parser"
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
         "@apify/eslint-config": "^0.1.3",
         "@babel/cli": "^7.12.13",
         "@babel/core": "^7.12.13",
+        "@babel/eslint-parser": "^7.13.14",
+        "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
         "@babel/preset-env": "^7.12.13",
         "@babel/register": "^7.12.13",

--- a/src/log.js
+++ b/src/log.js
@@ -13,7 +13,15 @@ const getDefaultOptions = () => ({
     data: {},
 });
 
-class Log {
+export class Log {
+    Log = Log;
+
+    LEVELS = LEVELS;
+
+    LoggerText = LoggerText;
+
+    LoggerJson = LoggerJson;
+
     constructor(options = {}) {
         options = { ...getDefaultOptions(), ...options };
 
@@ -163,10 +171,6 @@ class Log {
 
 const log = new Log();
 
-log.Log = Log;
-log.LEVELS = LEVELS;
-log.LoggerText = LoggerText;
-log.LoggerJson = LoggerJson;
-
 // Default export is an initialized instance of logger.
 export default log;
+module.exports = log;


### PR DESCRIPTION
Needed for `browser-pool` conversion to TypeScript, as TS complains that functions that return a new logger use a private class 

CC: @pocesar @B4nan @mnmkng,