### PR TITLE
fix: remove ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "commitlint": "^12.1.1",
         "deploy-web-to-s3": "^1.3.0",
         "eslint": "^7.25.0",
-        "gen-esm-wrapper": "^1.1.1",
         "husky": "^6.0.0",
         "jest": "^27.0.4",
         "lerna": "^4.0.0",

--- a/packages/consts/package.json
+++ b/packages/consts/package.json
@@ -3,14 +3,7 @@
     "version": "1.1.2",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,15 +27,11 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"
-    },
-    "devDependencies": {
-        "gen-esm-wrapper": "^1.1.1"
     }
 }

--- a/packages/datastructures/package.json
+++ b/packages/datastructures/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.0",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.0",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/hubspot_client/package.json
+++ b/packages/hubspot_client/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.0",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "yarn gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/image_proxy_client/package.json
+++ b/packages/image_proxy_client/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.0",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/input_schema/package.json
+++ b/packages/input_schema/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.3",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.4",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.5",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/salesforce_client/package.json
+++ b/packages/salesforce_client/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.0",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -3,14 +3,7 @@
     "version": "1.0.5",
     "description": "Tools and constants shared across Apify projects.",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "typings": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.js"
-        }
-    },
     "keywords": [
         "apify"
     ],
@@ -34,7 +27,6 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "npm run clean && npm run compile && npm run copy",
-        "postbuild": "npx gen-esm-wrapper dist/index.js dist/index.mjs",
         "clean": "rimraf ./dist",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "ts-node -T ../../scripts/copy.ts"


### PR DESCRIPTION
Due to issues in frontend repos using webpack to build, we decided to remove
the ESM support for now.

Related: https://github.com/apify/apify-web/pull/1169