### PR TITLE
fix: replace git-url-parse with native method

### DIFF
--- a/packages/markdown/package-lock.json
+++ b/packages/markdown/package-lock.json
@@ -1,0 +1,46 @@
+{
+    "name": "@apify/markdown",
+    "version": "1.0.8",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@apify/consts": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-1.1.3.tgz",
+            "integrity": "sha512-llOXk/z+vWoNFpjZARUuTclhoQXjSq0EyPUjiDc3k6kb3EZr4GJqz0pMI0ZA+iOh3//KcGXE+o8K8S3SzaEDXw=="
+        },
+        "@apify/log": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@apify/log/-/log-1.1.0.tgz",
+            "integrity": "sha512-kAxNI4nYu3hsCRurB5JF5HM70XmRV2VWCeWis4TRjTmh7lWQXHcVQkI8CAzfYIzqiY7iQFdvEO0scdZCJCbzQw==",
+            "requires": {
+                "@apify/consts": "^1.1.3",
+                "ansi-colors": "^4.1.1"
+            }
+        },
+        "@apify/utilities": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-1.1.1.tgz",
+            "integrity": "sha512-MpYYvzzngFINJxD2LqcWTlA5+wuH2npxlw0kV6Bl+pmDqOo/i+Uf5JxARc5fD6NXJujwCihR9U7tiZrji8OBog==",
+            "requires": {
+                "@apify/consts": "^1.1.3",
+                "@apify/log": "^1.1.0"
+            }
+        },
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+        },
+        "marked": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+            "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
+        },
+        "match-all": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/match-all/-/match-all-1.2.6.tgz",
+            "integrity": "sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ=="
+        }
+    }
+}

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -37,7 +37,6 @@
     "dependencies": {
         "@apify/consts": "^1.1.3",
         "@apify/utilities": "^1.1.1",
-        "git-url-parse": "^11.4.4",
         "marked": "^2.0.0",
         "match-all": "^1.2.6"
     }

--- a/packages/markdown/src/markdown_renderers.ts
+++ b/packages/markdown/src/markdown_renderers.ts
@@ -50,7 +50,7 @@ export function customHeadingRenderer(text: string, level: 1 | 2 | 3 | 4 | 5 | 6
     return `\n${' '.repeat(12)}<h${level} id="${headingId}"><a href="#${headingId}"></a>${headingText}</h${level}>`;
 }
 
-export function getRepoFullName(gitRepoUrl: string): string {
+export function parseRepoName(gitRepoUrl: string): string {
     const parsedRepoUrl = new URL(gitRepoUrl);
     const path = parsedRepoUrl.pathname.substr(1);
     // Can't use parsedRepoUrl.full_name on it's own as Bitbucket adds irrelevant path suffix to the end of it
@@ -62,7 +62,7 @@ export function getRepoFullName(gitRepoUrl: string): string {
  */
 export function generateRawGitRepoUrlPrefix(gitRepoUrl: string, gitBranchName: string): string | undefined {
     let urlPrefix;
-    const repoFullName = getRepoFullName(gitRepoUrl);
+    const repoFullName = parseRepoName(gitRepoUrl);
 
     // Avoid errors created by missing branch name / badly formed URLs
     const branchName = gitBranchName || GIT_MAIN_BRANCH;
@@ -84,7 +84,7 @@ export function generateRawGitRepoUrlPrefix(gitRepoUrl: string, gitBranchName: s
  */
 export function generateGitRepoUrlPrefix(gitRepoUrl: string, gitBranchName: string, href: string): string | undefined {
     let urlPrefix;
-    const repoFullName = getRepoFullName(gitRepoUrl);
+    const repoFullName = parseRepoName(gitRepoUrl);
 
     const hrefParts = href.split('/');
     const lastHrefPart = hrefParts[hrefParts.length - 1];

--- a/packages/markdown/src/markdown_renderers.ts
+++ b/packages/markdown/src/markdown_renderers.ts
@@ -1,4 +1,3 @@
-import gitUrlParse from 'git-url-parse';
 import { CONTACT_LINK_REGEX, GIT_MAIN_BRANCH } from '@apify/consts';
 import { isUrlRelative } from '@apify/utilities';
 
@@ -51,10 +50,11 @@ export function customHeadingRenderer(text: string, level: 1 | 2 | 3 | 4 | 5 | 6
     return `\n${' '.repeat(12)}<h${level} id="${headingId}"><a href="#${headingId}"></a>${headingText}</h${level}>`;
 }
 
-export function parseRepoName(gitRepoUrl: string): string {
-    const parsedRepoUrl = gitUrlParse(gitRepoUrl);
+export function getRepoFullName(gitRepoUrl: string): string {
+    const parsedRepoUrl = new URL(gitRepoUrl);
+    const path = parsedRepoUrl.pathname.substr(1);
     // Can't use parsedRepoUrl.full_name on it's own as Bitbucket adds irrelevant path suffix to the end of it
-    return parsedRepoUrl.full_name.split('/').slice(0, 2).join('/');
+    return path.split('/').slice(0, 2).join('/');
 }
 
 /**
@@ -62,7 +62,7 @@ export function parseRepoName(gitRepoUrl: string): string {
  */
 export function generateRawGitRepoUrlPrefix(gitRepoUrl: string, gitBranchName: string): string | undefined {
     let urlPrefix;
-    const repoFullName = parseRepoName(gitRepoUrl);
+    const repoFullName = getRepoFullName(gitRepoUrl);
 
     // Avoid errors created by missing branch name / badly formed URLs
     const branchName = gitBranchName || GIT_MAIN_BRANCH;
@@ -84,7 +84,7 @@ export function generateRawGitRepoUrlPrefix(gitRepoUrl: string, gitBranchName: s
  */
 export function generateGitRepoUrlPrefix(gitRepoUrl: string, gitBranchName: string, href: string): string | undefined {
     let urlPrefix;
-    const repoFullName = parseRepoName(gitRepoUrl);
+    const repoFullName = getRepoFullName(gitRepoUrl);
 
     const hrefParts = href.split('/');
     const lastHrefPart = hrefParts[hrefParts.length - 1];


### PR DESCRIPTION
Replacing the `git-url-parse` package in the markdown renderers with native Node URL parsing (it's not compatible with Safari).

