### PR TITLE
feat: Added FREE_MAIL_PROVIDERS to consts

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -604,3 +604,18 @@ export const MARKETPLACE_USER_ROLES = {
 };
 
 export const GIT_MAIN_BRANCH = 'main';
+
+// List of fee email providers
+export const FREE_MAIL_PROVIDERS = [
+    'gmail',
+    'yahoo',
+    '163.com',
+    'icloud.com',
+    'outlook',
+    'live',
+    'hotmail',
+    'seznam.cz',
+    'mailgun',
+    'protonmail',
+    'fmlcat',
+];


### PR DESCRIPTION
Will replace [this](https://github.com/apify/apify-web/blob/962ffaab29f349681c7b5f50fb44d4942266f763/src/ui/custom_components/CustomProjectForm/customProjectForm.consts.ts) and will be used in app to decide whether to call cognism api or not...

