### PR TITLE
feat: look up hubspot contact by HS additional emails

### DIFF
--- a/packages/hubspot_client/src/hubspot_client.ts
+++ b/packages/hubspot_client/src/hubspot_client.ts
@@ -197,14 +197,26 @@ export class HubspotClient {
     async searchContactByEmail(email: string): Promise<hubspot.contactsModels.SimplePublicObject | null> {
         if (!email) throw new Error('Arg "email" is required in HubspotClient.searchContactByEmail');
 
-        const filter = {
+        const primaryEmailFilter = {
             propertyName: 'email',
             operator: 'EQ',
             value: email,
         };
+
+        const additionalEmailsFilter = {
+            propertyName: 'hs_additional_emails',
+            operator: 'EQ',
+            value: email,
+        };
+
+        // multiple filterGroups -> logical OR
+        // multiple filters -> logical AND
         const publicObjectSearchRequest = {
             filterGroups: [{
-                filters: [filter],
+                filters: [primaryEmailFilter],
+            },
+            {
+                filters: [additionalEmailsFilter],
             }],
             sorts: [],
             properties: [],

--- a/test/hubspot_client.test.ts
+++ b/test/hubspot_client.test.ts
@@ -242,6 +242,12 @@ describe('HubspotClient', () => {
                         operator: 'EQ',
                         value: email,
                     }],
+                }, {
+                    filters: [{
+                        propertyName: 'hs_additional_emails',
+                        operator: 'EQ',
+                        value: email,
+                    }],
                 }],
                 sorts: [],
                 properties: [],
@@ -281,6 +287,12 @@ describe('HubspotClient', () => {
                 filterGroups: [{
                     filters: [{
                         propertyName: 'email',
+                        operator: 'EQ',
+                        value: email,
+                    }],
+                }, {
+                    filters: [{
+                        propertyName: 'hs_additional_emails',
                         operator: 'EQ',
                         value: email,
                     }],
@@ -471,6 +483,12 @@ describe('HubspotClient', () => {
                         operator: 'EQ',
                         value: user.emails[0].address,
                     }],
+                }, {
+                    filters: [{
+                        propertyName: 'hs_additional_emails',
+                        operator: 'EQ',
+                        value: user.emails[0].address,
+                    }],
                 }],
                 sorts: [],
                 properties: [],
@@ -527,6 +545,12 @@ describe('HubspotClient', () => {
                 filterGroups: [{
                     filters: [{
                         propertyName: 'email',
+                        operator: 'EQ',
+                        value: user.emails[0].address,
+                    }],
+                }, {
+                    filters: [{
+                        propertyName: 'hs_additional_emails',
                         operator: 'EQ',
                         value: user.emails[0].address,
                     }],


### PR DESCRIPTION
PR fixes error in syncing users to Hubspot. It happened when our primary email was not the primary email of the contact on HS side causing polluting our error logs.

Now we look up contact by both primary an additional emails. 