### PR TITLE
feat: add `@apify/timeout` package with abortable promise timeout helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ package | version
 `@apify/markdown` | [![NPM version](https://img.shields.io/npm/v/@apify/markdown.svg)](https://www.npmjs.com/package/@apify/markdown)
 `@apify/salesforce_client` | [![NPM version](https://img.shields.io/npm/v/@apify/salesforce_client.svg)](https://www.npmjs.com/package/@apify/salesforce_client)
 `@apify/utilities` | [![NPM version](https://img.shields.io/npm/v/@apify/utilities.svg)](https://www.npmjs.com/package/@apify/utilities)
+`@apify/timeout` | [![NPM version](https://img.shields.io/npm/v/@apify/timeout.svg)](https://www.npmjs.com/package/@apify/timeout)
 
 Internal utilities and constants shared across <a href="https://www.apify.com">Apify</a> projects.
 Unless you work at Apify ([interested?](https://apify.com/jobs)), you shouldn't use this package directly,

--- a/packages/timeout/package.json
+++ b/packages/timeout/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@apify/timeout",
+    "version": "0.1.0",
+    "description": "Helper for adding timeouts to promises that support easy cancellation.",
+    "main": "dist/index.js",
+    "typings": "dist/index.d.ts",
+    "keywords": [
+        "apify"
+    ],
+    "author": {
+        "name": "Apify",
+        "email": "support@apify.com",
+        "url": "https://apify.com"
+    },
+    "contributors": [
+        "Martin Adamek <martin@apify.com>"
+    ],
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/apify/apify-shared-js"
+    },
+    "bugs": {
+        "url": "https://github.com/apify/apify-shared-js/issues"
+    },
+    "homepage": "https://apify.com",
+    "scripts": {
+        "build": "npm run clean && npm run compile && npm run copy",
+        "clean": "rimraf ./dist",
+        "compile": "tsc -p tsconfig.build.json",
+        "copy": "ts-node -T ../../scripts/copy.ts"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/timeout/src/index.ts
+++ b/packages/timeout/src/index.ts
@@ -44,7 +44,7 @@ class InternalTimeoutError extends TimeoutError {
  * ```
  */
 export function tryCancel(): void {
-    const { signal } = storage.getStore()?.cancelTask ?? {};
+    const signal = storage.getStore()?.cancelTask.signal;
 
     if (signal?.aborted) {
         throw new InternalTimeoutError('Promise handler has been canceled due to a timeout');
@@ -71,13 +71,13 @@ export async function addTimeoutToPromise<T>(handler: () => Promise<T>, timeoutM
         cancelTimeout: new AbortController(),
         cancelTask: new AbortController(),
     };
-    let ret: T;
+    let returnValue: T;
 
     // calls handler, skips internal `TimeoutError`s that might have been thrown
     // via `tryCancel()` and aborts the timeout promise after the handler finishes
     const wrap = async () => {
         try {
-            ret = await handler();
+            returnValue = await handler();
         } catch (e) {
             if (!(e instanceof InternalTimeoutError)) {
                 throw e;
@@ -107,5 +107,5 @@ export async function addTimeoutToPromise<T>(handler: () => Promise<T>, timeoutM
         });
     });
 
-    return ret!;
+    return returnValue!;
 }

--- a/packages/timeout/src/index.ts
+++ b/packages/timeout/src/index.ts
@@ -1,0 +1,99 @@
+import { setTimeout } from 'timers/promises';
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface AbortContext {
+    cancelTimeout: AbortController;
+    cancelTask: AbortController;
+}
+
+/**
+ * AsyncLocalStorage instance that is used for baring the AbortContext inside user provided handler.
+ */
+export const storage = new AsyncLocalStorage<AbortContext>();
+
+/**
+ * Custom error class to handle tryCancel() checks.
+ * This should not be exposed to user land, as it will be caught in.
+ */
+export class TimeoutError extends Error {
+}
+
+/**
+ * Checks whether we are inside timeout handler created by this package, and cancels current
+ * task execution by throwing `TimeoutError`. This error will be ignored if the promise timed
+ * out already, or explicitly skipped in `addTimeoutToPromise`.
+ *
+ * Use this function after every async call that runs inside the timeout handler:
+ *
+ * ```ts
+ * async function doSomething() {
+ *     await doSomethingTimeConsuming();
+ *     tryCancel();
+ *     await doSomethingElse();
+ *     tryCancel();
+ * }
+ * ```
+ */
+export function tryCancel() {
+    const { signal } = storage.getStore()?.cancelTask ?? {};
+
+    if (signal?.aborted) {
+        throw new TimeoutError('Promise handler has been canceled due to a timeout');
+    }
+}
+
+/**
+ * Runs given handler and rejects with the given errorMessage (or Error instance)
+ * after given timeoutMillis, unless the original promise resolves or rejects earlier.
+ * Use `tryCancel()` function inside the handler after each await to finish its execution
+ * early when the timeout appears.
+ *
+ * ```ts
+ * const res = await addTimeoutToPromise(
+ *   () => handler(),
+ *   200,
+ *   'Handler timed out after 200ms!',
+ * );
+ * ```
+ */
+export async function addTimeoutToPromise<T>(handler: () => Promise<T>, timeoutMillis: number, errorMessage: string | Error): Promise<T> {
+    const cancelTimeout = new AbortController();
+    const cancelTask = new AbortController();
+    let ret: T;
+
+    const wrap = async () => {
+        try {
+            ret = await handler();
+        } catch (e) {
+            if (!(e instanceof TimeoutError)) {
+                throw e;
+            }
+        } finally {
+            storage.getStore()?.cancelTimeout.abort();
+        }
+    };
+
+    const timeout = async () => {
+        try {
+            await setTimeout(timeoutMillis, undefined, {
+                signal: storage.getStore()?.cancelTimeout.signal,
+            });
+            storage.getStore()?.cancelTask.abort();
+        } catch {
+            // ignore rejections (task finished and timeout has been cancelled
+            return;
+        }
+
+        throw errorMessage instanceof Error
+            ? errorMessage
+            : new TimeoutError(errorMessage);
+    };
+
+    await new Promise((resolve, reject) => {
+        storage.run({ cancelTimeout, cancelTask }, () => {
+            Promise.race([timeout(), wrap()]).then(resolve, reject);
+        });
+    });
+
+    return ret!;
+}

--- a/packages/timeout/tsconfig.build.json
+++ b/packages/timeout/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/timeout/tsconfig.json
+++ b/packages/timeout/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -3,7 +3,9 @@ describe('timeout with abort controller', () => {
         // empty test so jest won't fail in node < 15 due to no tests being executed
     });
 
-    if (Number(process.version.match(/v(\d+)/)?.[1] ?? null) < 15) {
+    const [nodeVersion] = process.versions.node.split('.', 1);
+
+    if (+nodeVersion < 15) {
         // skip tests as this package requires node 15+
         return;
     }

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,0 +1,64 @@
+import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
+import { setTimeout } from 'timers/promises';
+
+describe('SPLIT_PATH_REGEX', () => {
+    if (Number(process.version.match(/v(\d+)/)?.[1] ?? null) < 15) {
+        // skip tests as this package requires node 15+
+        return;
+    }
+
+    let position = 0;
+
+    async function handler() {
+        await setTimeout(30);
+        tryCancel();
+        position++;
+        await setTimeout(30);
+        tryCancel();
+        position++;
+        await setTimeout(30);
+        tryCancel();
+        position++;
+        await setTimeout(30);
+        tryCancel();
+        position++;
+        await setTimeout(30);
+        tryCancel();
+        position++;
+
+        return 123;
+    }
+
+    beforeEach(() => {
+        position = 0;
+    });
+
+    it('passes without timeouting', async () => {
+        const res = await addTimeoutToPromise(
+            () => handler(),
+            200,
+            'timed out',
+        );
+        expect(res).toBe(123);
+        expect(position).toBe(5);
+    });
+
+    it('timeouts in the middle', async () => {
+        await expect(addTimeoutToPromise(
+            () => handler(),
+            100,
+            'timed out',
+        )).rejects.toThrowError();
+        expect(position).toBe(3);
+    });
+
+    it('timeouts with given error instance', async () => {
+        const err = new Error('123');
+        await expect(addTimeoutToPromise(
+            () => handler(),
+            100,
+            err,
+        )).rejects.toThrowError(err);
+        expect(position).toBe(3);
+    });
+});

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,11 +1,14 @@
-import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
-import { setTimeout } from 'timers/promises';
-
 describe('SPLIT_PATH_REGEX', () => {
     if (Number(process.version.match(/v(\d+)/)?.[1] ?? null) < 15) {
         // skip tests as this package requires node 15+
         return;
     }
+
+    // we need to import via require after the above check to not fail on node < 15
+    // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
+    const { addTimeoutToPromise, tryCancel } = require('@apify/timeout');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
+    const { setTimeout } = require('timers/promises');
 
     let position = 0;
 

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,4 +1,8 @@
 describe('timeout with abort controller', () => {
+    it('empty', async () => {
+        // empty test so jest won't fail in node < 15 due to no tests being executed
+    });
+
     if (Number(process.version.match(/v(\d+)/)?.[1] ?? null) < 15) {
         // skip tests as this package requires node 15+
         return;

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -68,4 +68,22 @@ describe('timeout with abort controller', () => {
         )).rejects.toThrowError(err);
         expect(position).toBe(3);
     });
+
+    it('timeouts with nesting', async () => {
+        // this will timeout and cause failure, but it will happen sooner than in 200ms, so err 1 will be thrown
+        async function handler2() {
+            await addTimeoutToPromise(
+                () => handler(),
+                100,
+                'err 1',
+            );
+        }
+
+        await expect(addTimeoutToPromise(
+            () => handler2(),
+            200,
+            'err 2',
+        )).rejects.toThrowError('err 1');
+        expect(position).toBe(3);
+    });
 });

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,4 +1,4 @@
-describe('SPLIT_PATH_REGEX', () => {
+describe('timeout with abort controller', () => {
     if (Number(process.version.match(/v(\d+)/)?.[1] ?? null) < 15) {
         // skip tests as this package requires node 15+
         return;


### PR DESCRIPTION
Runs given handler and rejects with the given `errorMessage` (or Error instance) after given `timeoutMillis`, unless the original promise resolves or rejects earlier. Use `tryCancel()` function inside the handler after each await to finish its execution early when the timeout appears.

```ts
import { addTimeoutToPromise, tryCancel } from '@apify/timeout';

async function doSomething() {
    await doSomethingTimeConsuming();
    tryCancel();
    await doSomethingElse();
    tryCancel();
}

const res = await addTimeoutToPromise(
  () => handler(),
  200,
  'Handler timed out after 200ms!',
);
```

This uses `AsyncLocalStorage` to hold the `AbortController` instances created inside the `addTimeoutToPromise` function. The context is shared for this package, and respects nesting of `addTimeoutToPromise` calls. This means it can be used in different packages to cancel the same nested handler, e.g. we can create the timeout in SDK and use `tryCancel` from inside browser pool (we can still handle the timeouts explicitly in browser pool, and it will automatically used the upper context if there is some0.