### PR TITLE
fix: consecutive dots in email are not allowed

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -1,8 +1,11 @@
 /**
  * Email validation regexp adapted from https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
  * with our restriction that hostname must be a TLD! (will not match example@localhost)
+ * and two consecutive dots in name are not allowed (based on Mailgun convention, will not match ex..amle@example.com)
  */
-export const EMAIL_REGEX_STR = '[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+)*\\.{0,1}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+'; // eslint-disable-line max-len
+const subRegexOne = 'a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-';
+const subRegexTwo = 'a-zA-Z0-9';
+export const EMAIL_REGEX_STR = `[${subRegexOne}]+(?:\\.[${subRegexOne}]+)*\\.{0,1}@[${subRegexTwo}](?:[${subRegexTwo}-]{0,61}[${subRegexTwo}])?(?:\\.[${subRegexTwo}](?:[${subRegexTwo}-]{0,61}[${subRegexTwo}])?)+`; // eslint-disable-line max-len
 
 /**
  * Matches a string containing valid email

--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -1,9 +1,3 @@
-/**
- * Email validation regexp adapted from https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
- * with our restriction that hostname must be a TLD! (will not match example@localhost)
- * and two consecutive dots in name are not allowed (based on Mailgun convention, will not match ex..amle@example.com)
- */
-
 // Parts for building an email regex (email will be constructed as `name@domain`)
 // name parts can be alnum + some special characters
 const namePartSubRegexStr = '[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+';
@@ -14,9 +8,18 @@ const domainPartSubRegexStr = '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'; /
 // doman is 2+ domain parts joined by periods (no leading or dangling period, no consecutive periods)
 const domainSubRegexStr = `${domainPartSubRegexStr}(?:\\.${domainPartSubRegexStr})+`;
 
-export const EMAIL_REGEX_STR = `^${nameSubRegexStr}@${domainSubRegexStr}$`;
+/**
+ * Email validation regexp adapted from https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
+ * with our restriction that hostname must be a TLD! (will not match example@localhost)
+ * and two consecutive dots in name are not allowed (based on Mailgun convention, will not match ex..amle@example.com)
+ */
+export const EMAIL_REGEX_STR = `${nameSubRegexStr}@${domainSubRegexStr}`;
 
-export const EMAIL_REGEX = new RegExp(EMAIL_REGEX_STR);
+/**
+ * Matches a string containing valid email
+ * Hostname must be a TLD! (will not match example@localhost)
+ */
+export const EMAIL_REGEX = new RegExp(`^${EMAIL_REGEX_STR}$`);
 
 /**
  * Comes from https://github.com/jonschlinkert/is-git-url/ but we have:

--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -2,7 +2,7 @@
  * Email validation regexp adapted from https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
  * with our restriction that hostname must be a TLD! (will not match example@localhost)
  */
-export const EMAIL_REGEX_STR = '[a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+'; // eslint-disable-line max-len
+export const EMAIL_REGEX_STR = '[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+)*.{0,1}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+'; // eslint-disable-line max-len
 
 /**
  * Matches a string containing valid email

--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -2,7 +2,7 @@
  * Email validation regexp adapted from https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
  * with our restriction that hostname must be a TLD! (will not match example@localhost)
  */
-export const EMAIL_REGEX_STR = '[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+)*.{0,1}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+'; // eslint-disable-line max-len
+export const EMAIL_REGEX_STR = '[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+)*\\.{0,1}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+'; // eslint-disable-line max-len
 
 /**
  * Matches a string containing valid email

--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -3,15 +3,20 @@
  * with our restriction that hostname must be a TLD! (will not match example@localhost)
  * and two consecutive dots in name are not allowed (based on Mailgun convention, will not match ex..amle@example.com)
  */
-const subRegexOne = 'a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-';
-const subRegexTwo = 'a-zA-Z0-9';
-export const EMAIL_REGEX_STR = `[${subRegexOne}]+(?:\\.[${subRegexOne}]+)*\\.{0,1}@[${subRegexTwo}](?:[${subRegexTwo}-]{0,61}[${subRegexTwo}])?(?:\\.[${subRegexTwo}](?:[${subRegexTwo}-]{0,61}[${subRegexTwo}])?)+`; // eslint-disable-line max-len
 
-/**
- * Matches a string containing valid email
- * Hostname must be a TLD! (will not match example@localhost)
- */
-export const EMAIL_REGEX = new RegExp(`^${EMAIL_REGEX_STR}$`);
+// Parts for building an email regex (email will be constructed as `name@domain`)
+// name parts can be alnum + some special characters
+const namePartSubRegexStr = '[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+';
+// name is 1+ name parts joined by periods (no leading or dangling period, no consecutive periods)
+const nameSubRegexStr = `${namePartSubRegexStr}(?:\\.${namePartSubRegexStr})*`;
+// domain parts can be alnum and dash characters (no leading and dangling dashes, max 63 chars long)
+const domainPartSubRegexStr = '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'; //
+// doman is 2+ domain parts joined by periods (no leading or dangling period, no consecutive periods)
+const domainSubRegexStr = `${domainPartSubRegexStr}(?:\\.${domainPartSubRegexStr})+`;
+
+export const EMAIL_REGEX_STR = `^${nameSubRegexStr}@${domainSubRegexStr}$`;
+
+export const EMAIL_REGEX = new RegExp(EMAIL_REGEX_STR);
 
 /**
  * Comes from https://github.com/jonschlinkert/is-git-url/ but we have:

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -126,6 +126,7 @@ const tests = {
             'test@localhost',
             'not an email',
             '@example.com',
+            'test..test@example.com' // more dots not allowed by mailgun
         ],
     },
 

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -124,13 +124,16 @@ const tests = {
         ],
         invalid: [
             ' test@example.com',
+            'test@example.com ',
             'test@@example.com',
             'test@localhost',
             'not an email',
             '@example.com',
             'test..test@example.com',
-            'test...test@exmaple.com',
-            'test.test.test..x@example.com',
+            'test.@example.com',
+            '.test@example.com',
+            '...test@example.com',
+            'test@example_example.com',
         ],
     },
 

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -126,7 +126,7 @@ const tests = {
             'test@localhost',
             'not an email',
             '@example.com',
-            'test..test@example.com' // more dots not allowed by mailgun
+            'test..test@example.com',
         ],
     },
 

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -119,6 +119,8 @@ const tests = {
             'a-b@example.at',
             'test@my.example.com',
             'test@my-super.example.com',
+            'a.b.c+123~@example.com',
+            'a.b.c.d@example.com',
         ],
         invalid: [
             ' test@example.com',
@@ -127,6 +129,8 @@ const tests = {
             'not an email',
             '@example.com',
             'test..test@example.com',
+            'test...test@exmaple.com',
+            'test.test.test..x@example.com',
         ],
     },
 

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -133,6 +133,9 @@ const tests = {
             'test.@example.com',
             '.test@example.com',
             '...test@example.com',
+            'example@-test.com',
+            'example@.test.test.com',
+            // no underscore in domain name now but the standards are not 100% clear, might be reviewed
             'test@example_example.com',
         ],
     },


### PR DESCRIPTION
Solving LogDNA error bug, more info in Slack [here](https://apifier.slack.com/archives/G0134LE0JUB/p1638267910154500). 

In general:
Email with consecutive dots in it should not be allowed to register. It was tested by [Mailgun API](https://documentation.mailgun.com/en/latest/api-email-validation.html#request-examples) where those emails are marked as invalid.

The new regex was tested in MongoDB using the query below, now it returns 19 invalid emails, the same number as currently used regex:
`db.getCollection('users').find({
  $and: [
      { 'emails.address': { $not: { $regex: /NEW_REGEX/  } } },
      { 'emails.address': { $ne: null } },
  ]
})`

Moreover, new `invalid email` was added to tests.

Any comments / reviews appreciated :-) 
Thanks! 