### PR TITLE
Add lazy loading to markdown images

### DIFF
--- a/packages/markdown/src/markdown_renderers.ts
+++ b/packages/markdown/src/markdown_renderers.ts
@@ -159,5 +159,5 @@ export function customImageRenderer(href: string, text: string, gitRepoUrl: stri
         href = `${urlPrefix}/${cleanedHref}`;
     }
 
-    return `<img src="${href}" alt="${text}" />`;
+    return `<img src="${href}" alt="${text}" loading="lazy" />`;
 }


### PR DESCRIPTION
In the interest of perf gainz, adding lazy loading to images rendered with the markdown renderer - ones in actor readmes