### PR TITLE
fix(web): md to tab title for Javascript

### DIFF
--- a/packages/markdown/src/marked.ts
+++ b/packages/markdown/src/marked.ts
@@ -13,8 +13,8 @@ import { customHeadingRenderer } from './markdown_renderers';
  * In case tab title can't be resolved from language using this mapping, the language itself is used as a tab title.
  */
 const LANGUAGE_TO_TAB_TITLE = {
-    js: 'Node.JS',
-    javascript: 'Node.js',
+    js: 'JavaScript',
+    javascript: 'JavaScript',
     nodejs: 'Node.js',
     bash: 'Bash',
     curl: 'cURL',

--- a/test/marked.test.ts
+++ b/test/marked.test.ts
@@ -69,7 +69,7 @@ describe('apifyMarked custom renderer works', () => {
         expect(codeTabsObjectPerIndex).toEqual(
             {
                 '0': {
-                    'Javascript': { language: 'javascript', code: "console.log('Some JS code');" },
+                    'JavaScript': { language: 'javascript', code: "console.log('Some JS code');" },
                     Python: {
                         language: 'python',
                         code: "print('Some python code');\n" +
@@ -81,7 +81,7 @@ describe('apifyMarked custom renderer works', () => {
                     'Bash': { language: 'bash', code: 'echo "Some bash code"' }
                 },
                 '1': {
-                    'Javascript': { language: 'javascript', code: "console.log('Your standard javascript code block')" },
+                    'JavaScript': { language: 'javascript', code: "console.log('Your standard javascript code block')" },
                 },
                 '2': {
                     'Custom title': { language: 'javascript', code: "console.log('Some JS code 2');" },

--- a/test/marked.test.ts
+++ b/test/marked.test.ts
@@ -69,7 +69,7 @@ describe('apifyMarked custom renderer works', () => {
         expect(codeTabsObjectPerIndex).toEqual(
             {
                 '0': {
-                    'Node.js': { language: 'javascript', code: "console.log('Some JS code');" },
+                    'Javascript': { language: 'javascript', code: "console.log('Some JS code');" },
                     Python: {
                         language: 'python',
                         code: "print('Some python code');\n" +
@@ -81,7 +81,7 @@ describe('apifyMarked custom renderer works', () => {
                     'Bash': { language: 'bash', code: 'echo "Some bash code"' }
                 },
                 '1': {
-                    'Node.js': { language: 'javascript', code: "console.log('Your standard javascript code block')" },
+                    'Javascript': { language: 'javascript', code: "console.log('Your standard javascript code block')" },
                 },
                 '2': {
                     'Custom title': { language: 'javascript', code: "console.log('Some JS code 2');" },

--- a/test/marked.test.ts
+++ b/test/marked.test.ts
@@ -8,7 +8,7 @@ const MARKDOWN_UNDER_TEST = `
 
 ## Code block with tabs
 \`\`\`marked-tabs
-<marked-tab header="Node.js" lang="javascript">
+<marked-tab header="JavaScript" lang="javascript">
 console.log('Some JS code');
 </marked-tab>
 


### PR DESCRIPTION
When writing "js / javascript" in md for docs, it always ended up with `Node.js` code tab instead of `Javasript`. Reported [here](https://apifier.slack.com/archives/C0L33UM7Z/p1642588984124400) .

cc @mnmkng 