### PR TITLE
feat(hubspot_client): add support for kanban url to contact

### DIFF
--- a/packages/hubspot_client/src/hubspot_client.ts
+++ b/packages/hubspot_client/src/hubspot_client.ts
@@ -38,6 +38,7 @@ const ALLOWED_USER_FIELDS = {
     billing_email__c: _.isString,
 
     lifecyclestage: _.isString,
+    apify_kanban_link_: _.isString,
 };
 
 // Same as above, but for invoice
@@ -317,6 +318,12 @@ export class HubspotClient {
 
         if (user.admin && user.admin.yearlyRevenueUsd) {
             data.annualrevenue = user.admin.yearlyRevenueUsd;
+        }
+
+        // Sets link to latest MP project on MP kanban
+        if (user.kanbanUrl) {
+            // eslint-disable-next-line no-underscore-dangle
+            data.apify_kanban_link_ = user.kanbanUrl;
         }
 
         if (isNew) {

--- a/test/hubspot_client.test.ts
+++ b/test/hubspot_client.test.ts
@@ -693,6 +693,7 @@ describe('HubspotClient', () => {
                         engagementType: 'SALES_REP_MEDIUM_INVOLVEMENT',
                     },
                 ],
+                kanbanUrl: 'https://console-securitybyobscurity.apify.com/orders/iJuo3Rvyg5LTbsB6F',
             };
 
             const contactId = 801;
@@ -714,6 +715,7 @@ describe('HubspotClient', () => {
                 createdAt: '2021-04-18T21:23:09.435Z',
                 updatedAt: '2021-04-19T08:32:14.894Z',
                 archived: false,
+                kanbanUrl: 'https://console-securitybyobscurity.apify.com/orders/iJuo3Rvyg5LTbsB6F',
             };
 
             const transformedData = hubspotClient._transformUser(userData);

--- a/test/hubspot_client.test.ts
+++ b/test/hubspot_client.test.ts
@@ -711,11 +711,11 @@ describe('HubspotClient', () => {
                     lifecyclestage: 'customer',
                     segment_paying_customer: 'true',
                     subscription_plan: 'CUSTOM',
+                    apify_kanban_link_: 'https://console-securitybyobscurity.apify.com/orders/iJuo3Rvyg5LTbsB6F',
                 },
                 createdAt: '2021-04-18T21:23:09.435Z',
                 updatedAt: '2021-04-19T08:32:14.894Z',
                 archived: false,
-                kanbanUrl: 'https://console-securitybyobscurity.apify.com/orders/iJuo3Rvyg5LTbsB6F',
             };
 
             const transformedData = hubspotClient._transformUser(userData);


### PR DESCRIPTION
We want to set `Apify kanban link` property at HS contact to the link to the latest MP project.