### PR TITLE
feat: remove lowercasing from markdown hrefs

### DIFF
--- a/packages/markdown/src/markdown_renderers.ts
+++ b/packages/markdown/src/markdown_renderers.ts
@@ -126,8 +126,7 @@ export function customLinkRenderer(href: string, text: string, gitRepoUrl: strin
     // Handle anchor links, local Apify links, and mailto
     // Return Apify domain links without rel="nofollow" for SEO
     if (href.startsWith('#') || href.includes('apify.com') || CONTACT_LINK_REGEX.test(href)) {
-        // Ensure that anchors have lowercase href
-        return `<a href="${href.toLowerCase()}">${text}</a>`;
+        return `<a href="${href}">${text}</a>`;
     }
 
     // Only target relative URLs, which are used to refer to the git repo, and not anchors or absolute URLs


### PR DESCRIPTION
Lowercasing the hrefs breaks certain links, e.g. links containing actor IDs, so best to leave it up to the markdown author to control the capital letters of the links