### PR TITLE
fix(consts): remove g flag from regex

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -25,7 +25,7 @@ export const EMAIL_REGEX = new RegExp(`^${EMAIL_REGEX_STR}$`);
  * Matches a string containing single email or multiple emails separated by comma
  * Hostname must be a TLD! (will not match example@localhost)
  */
-export const COMMA_SEPARATED_EMAILS_REGEX = new RegExp(`^(${EMAIL_REGEX_STR})( *, *${EMAIL_REGEX_STR})*$`, 'g');
+export const COMMA_SEPARATED_EMAILS_REGEX = new RegExp(`^(${EMAIL_REGEX_STR})( *, *${EMAIL_REGEX_STR})*$`);
 
 /**
  * Comes from https://github.com/jonschlinkert/is-git-url/ but we have:


### PR DESCRIPTION
For some reason my webstrom adds a `g` flag by default and I didn't noticed 😎 