### PR TITLE
feat(consts): add string version of comma separated emails regex

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -25,7 +25,13 @@ export const EMAIL_REGEX = new RegExp(`^${EMAIL_REGEX_STR}$`);
  * Matches a string containing single email or multiple emails separated by comma
  * Hostname must be a TLD! (will not match example@localhost)
  */
-export const COMMA_SEPARATED_EMAILS_REGEX = new RegExp(`^(${EMAIL_REGEX_STR})( *, *${EMAIL_REGEX_STR})*$`);
+export const COMMA_SEPARATED_EMAILS_REGEX_STR = `(${EMAIL_REGEX_STR})( *, *${EMAIL_REGEX_STR})*`;
+
+/**
+ * Matches a string containing single email or multiple emails separated by comma
+ * Hostname must be a TLD! (will not match example@localhost)
+ */
+export const COMMA_SEPARATED_EMAILS_REGEX = new RegExp(`^${COMMA_SEPARATED_EMAILS_REGEX_STR}$`);
 
 /**
  * Comes from https://github.com/jonschlinkert/is-git-url/ but we have:


### PR DESCRIPTION
This adds the string version of `COMMA_SEPARATED_EMAILS_REGEX` in similar way as other regexes