### PR TITLE
feat: Allow $schema prop in Input schema

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -2,6 +2,9 @@
     "title": "JSON schema of Apify Actor INPUT_SCHEMA.json",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "title": {
             "type": "string"
         },


### PR DESCRIPTION
Allows adding schema URL to Input Schema, which will cause the majority of editors to download the schema automatically and enable autocomplete/validation.

```
"$schema": "https://raw.githubusercontent.com/apify/apify-shared-js/master/packages/input_schema/src/schema.json",
```

![image](https://user-images.githubusercontent.com/697301/171993521-6d9f819c-7916-4f93-bc84-36125f164a7f.png)
