### PR TITLE
feat(input_schema): better error message for wrong enum value

### DIFF
--- a/packages/input_schema/src/input_schema.ts
+++ b/packages/input_schema/src/input_schema.ts
@@ -43,6 +43,10 @@ export function parseAjvError(
     } else if (error.keyword === 'additionalProperties') {
         fieldKey = error.params.additionalProperty;
         message = m('inputSchema.validation.additionalProperty', { rootName, fieldKey });
+    } else if (error.keyword === 'enum') {
+        fieldKey = error.instancePath.split('/').pop()!;
+        const errorMessage = `${error.message}: "${error.params.allowedValues.join('", "')}"`;
+        message = m('inputSchema.validation.generic', { rootName, fieldKey, message: errorMessage });
     } else {
         fieldKey = error.instancePath.split('/').pop()!;
         message = m('inputSchema.validation.generic', { rootName, fieldKey, message: error.message });

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -78,7 +78,7 @@ describe('input_schema.json', () => {
             };
 
             expect(() => validateInputSchema(validator, schema)).toThrow(
-                'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values)',
+                'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values: "json", "hidden")',
             );
         });
 

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -140,7 +140,8 @@ describe('input_schema.json', () => {
             };
 
             expect(() => validateInputSchema(validator, schema)).toThrow(
-                'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values)',
+                'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values: '
+                + '"javascript", "python", "textfield", "textarea", "hidden")',
             );
         });
 


### PR DESCRIPTION
This adds a better error message when a field of type `enum` has a wrong value.

Before:
`Field schema.properties.message.editor must be equal to one of the allowed values`
After:
`Field schema.properties.message.editor must be equal to one of the allowed values: "javascript", "python", "textfield", "textarea", "hidden"`