### PR TITLE
fix: enforce unique items in "enum" input schema properties

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -66,7 +66,8 @@
 
                 "enum": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": { "type": "string" },
+                    "uniqueItems": true
                 },
                 "enumTitles": {
                     "type": "array",


### PR DESCRIPTION
If you had duplicate items in an `enum` field definition in an input schema, the actor with such input schema would build successfuly, but then the input schema validation would not work. This fixes it.

Resolves #133.