### PR TITLE
fix(markdown): marked package named imports

### DIFF
--- a/packages/markdown/src/marked.ts
+++ b/packages/markdown/src/marked.ts
@@ -1,6 +1,8 @@
-import { Renderer, lexer, parser } from 'marked';
+import marked from 'marked';
 import matchAll from 'match-all';
 import { customHeadingRenderer } from './markdown_renderers';
+
+const { Renderer, lexer, parser } = marked;
 
 /**
  * Map from the language of a fenced code block to the title of corresponding tab.


### PR DESCRIPTION
Cannot import from `@apify/markdown` in project with `"type": "module"`. Minimal repo:

```
// package.json

{
  "name": "module-test",
  "main": "index.js",
  "type": "module",
  "scripts": {
    "start": "node index.js"
  },
  "dependencies": {
    "@apify/markdown": "^2.0.10"
  }
}
```

```
// index.js

import { apifyMarked } from "@apify/markdown"

console.log(apifyMarked)
```

Run script: `npm run start`

Error:
```
file:///Users/nguyendan/work/module/node_modules/@apify/markdown/index.mjs:99
import { Renderer, lexer, parser } from "marked";
                   ^^^^^
SyntaxError: Named export 'lexer' not found. The requested module 'marked' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'marked';
const { Renderer, lexer, parser } = pkg;
```

I have played around locally in `node_modules` and this should hopefully fix it.