### PR TITLE
feat: allow using variables in fields of webhook payload template

### DIFF
--- a/packages/utilities/src/webhook_payload_template.ts
+++ b/packages/utilities/src/webhook_payload_template.ts
@@ -88,6 +88,7 @@ export class WebhookPayloadTemplate {
         if (type !== 'string') throw new Error(`Cannot parse a ${type} payload template.`);
         const template = new WebhookPayloadTemplate(payloadTemplate, allowedVariables, context);
         const data = template._parse(); // eslint-disable-line no-underscore-dangle
+        // TODO: Maybe make this configurable via some options, to make "sure" about backwards compatibility?
         return template._interpolate(data); // eslint-disable-line no-underscore-dangle
     }
 
@@ -176,7 +177,6 @@ export class WebhookPayloadTemplate {
         return value;
     }
 
-    // TODO: Just replace the variables in this case
     private _interpolateString(value: string): string {
         // If the string matches exactly, we return the variable value including the type
         if (value.match(/^\{\{var:([a-zA-Z0-9.]*)\}\}$/)) {

--- a/packages/utilities/src/webhook_payload_template.ts
+++ b/packages/utilities/src/webhook_payload_template.ts
@@ -152,17 +152,7 @@ export class WebhookPayloadTemplate {
         }
     }
 
-    /**
-     * Process variables that are inside strings.
-     *
-     * @param data
-     * @returns
-     */
-    private _interpolate(data: Record<string, any>): Record<string, any> {
-        return this._interpolateWhatever(data);
-    }
-
-    private _interpolateWhatever(value: any): any {
+    private _interpolate(value: any): any {
         if (typeof value === 'string') {
             return this._interpolateString(value);
         }
@@ -195,13 +185,13 @@ export class WebhookPayloadTemplate {
     private _interpolateObject(value: Record<string, any>): Record<string, any> {
         const result = {};
         Object.entries(value).forEach(([key, v]) => {
-            result[key] = this._interpolateWhatever(v);
+            result[key] = this._interpolate(v);
         });
         return result;
     }
 
     private _interpolateArray(value: Array<any>): Array<any> {
-        return value.map(this._interpolateWhatever.bind(this));
+        return value.map(this._interpolate.bind(this));
     }
 
     private _findPositionOfNextVariable(startIndex = 0): ParsePosition | null {

--- a/packages/utilities/src/webhook_payload_template.ts
+++ b/packages/utilities/src/webhook_payload_template.ts
@@ -177,7 +177,7 @@ export class WebhookPayloadTemplate {
     private _interpolateString(value: string): string {
         // If the string matches exactly, we return the variable value including the type
         if (value.match(/^\{\{([a-zA-Z0-9.]+)\}\}$/)) {
-            // This just strpis the {{ and }}
+            // This just strips the {{ and }}
             const variableName = value.substring(2, value.length - 2);
             this._validateVariableName(variableName);
             return this._getVariableValue(variableName);

--- a/test/webhook_payload_template.test.ts
+++ b/test/webhook_payload_template.test.ts
@@ -114,6 +114,23 @@ describe('WebhookPayloadTemplate', () => {
         }
     });
 
+    it('replaces variables in strings', () => {
+        const payload = WebhookPayloadTemplate.parse(`
+        {
+            "justVariable": "{{var:foo}}",
+            "someOtherContent": "bar{{var:foo}}",
+            "twoVariables": "bar{{var:foo}}baz{{var:foo}}bar{{var:lol}}",
+            "bar": {{xyz}}
+        }`, null, {
+            foo: 'foo',
+            lol: 'lol',
+        });
+        expect(payload.justVariable).toBe('foo');
+        expect(payload.someOtherContent).toBe('barfoo');
+        expect(payload.twoVariables).toBe('barfoobazfoobarlol');
+        expect(payload.bar).toBe(null);
+    });
+
     it('should throw InvalidJsonError on invalid json', () => {
         try {
             WebhookPayloadTemplate.parse(invalidJson);

--- a/test/webhook_payload_template.test.ts
+++ b/test/webhook_payload_template.test.ts
@@ -22,7 +22,8 @@ const validTemplate = `
 const validTemplateWithVariableInString = `
 {
     "foo": "bar\\"{{foo}}\\"",
-    "bar": {{xyz}}
+    "bar": {{xyz}},
+    "baz": "{{foo}}"
 }
 `;
 
@@ -102,7 +103,7 @@ describe('WebhookPayloadTemplate', () => {
         expect(payload).toEqual(context);
     });
 
-    it('does not replace variables in strings', () => {
+    it('does not replace variables in strings by default', () => {
         const payload = WebhookPayloadTemplate.parse(validTemplateWithVariableInString);
         expect(payload.foo).toBe('bar"{{foo}}"');
 
@@ -114,21 +115,38 @@ describe('WebhookPayloadTemplate', () => {
         }
     });
 
-    it('replaces variables in strings', () => {
+    it('replaces variables in strings if interpolateStrings=true', () => {
+        const context = {
+            foo: 'hello',
+            lol: 'world',
+            resource: {
+                defaultDatasetId: 'dataset-123',
+            },
+            arrayField: [1, 2, 3],
+        };
         const payload = WebhookPayloadTemplate.parse(`
         {
-            "justVariable": "{{var:foo}}",
-            "someOtherContent": "bar{{var:foo}}",
-            "twoVariables": "bar{{var:foo}}baz{{var:foo}}bar{{var:lol}}",
-            "bar": {{xyz}}
-        }`, null, {
-            foo: 'foo',
-            lol: 'lol',
-        });
-        expect(payload.justVariable).toBe('foo');
-        expect(payload.someOtherContent).toBe('barfoo');
-        expect(payload.twoVariables).toBe('barfoobazfoobarlol');
+            "justVariable": "{{foo}}",
+            "someOtherContent": "bar{{foo}}",
+            "twoVariables": "bar{{foo}}baz{{foo}}bar{{lol}}",
+            "bar": {{xyz}},
+            "datasetId": "{{resource.defaultDatasetId}}",
+            "arrayField": "{{arrayField}}",
+            "arrayFieldInString": "This is my array {{arrayField}}",
+            "resourceWrapped": "{{resource}}",
+            "resourceDirect": {{resource}},
+            "resourceInString": "This is my object {{resource}}"
+        }`, null, context, { interpolateStrings: true });
+        expect(payload.justVariable).toBe('hello');
+        expect(payload.someOtherContent).toBe('barhello');
+        expect(payload.twoVariables).toBe('barhellobazhellobarworld');
         expect(payload.bar).toBe(null);
+        expect(payload.datasetId).toBe('dataset-123');
+        expect(payload.arrayField).toStrictEqual(context.arrayField);
+        expect(payload.arrayFieldInString).toBe('This is my array 1,2,3');
+        expect(payload.resourceWrapped).toStrictEqual(context.resource);
+        expect(payload.resourceDirect).toStrictEqual(context.resource);
+        expect(payload.resourceInString).toBe('This is my object [object Object]');
     });
 
     it('should throw InvalidJsonError on invalid json', () => {


### PR DESCRIPTION
This PR
 - makes parsing slightly more effective (one pass only)
 - adds support for "interpolation" - using `{{var:resource.defaultDatasetId}}` syntax in strings - ie. adding the possibility to pass it to the input.
 - It's intentionally slightly different mechanism than the parsing, as it does a different thing.
 
 Theoretically it's breaking, I have an idea how to deal with it, just not sure if it's necessary.