### PR TITLE
fix(input_schema): disallow empty `enum`s in input schema

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -63,15 +63,16 @@
                 "nullable": { "type": "boolean" },
                 "sectionCaption": { "type": "string" },
                 "sectionDescription": { "type": "string" },
-
                 "enum": {
                     "type": "array",
                     "items": { "type": "string" },
+                    "minItems": 1,
                     "uniqueItems": true
                 },
                 "enumTitles": {
                     "type": "array",
-                    "items": { "type": "string" }
+                    "items": { "type": "string" },
+                    "minItems": 1
                 }
             },
             "required": ["type", "title", "description", "enum"]

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -17,6 +17,21 @@ describe('input_schema.json', () => {
                         description: 'Some description ...',
                         editor: 'json',
                     },
+                    myField2: {
+                        title: 'Enum without titles',
+                        type: 'string',
+                        description: 'Some description ...',
+                        editor: 'select',
+                        enum: ['a', 'b', 'c'],
+                    },
+                    myField3: {
+                        title: 'Enum with titles',
+                        type: 'string',
+                        description: 'Some description ...',
+                        editor: 'select',
+                        enum: ['a', 'b', 'c'],
+                        enumTitles: ['A', 'B', 'C'],
+                    },
                 },
             };
 
@@ -205,6 +220,47 @@ describe('input_schema.json', () => {
 
             expect(() => validateInputSchema(validator, schema)).toThrow(
                 'Input schema is not valid (Field schema.properties.myField.enum.0 must be string)',
+            );
+        });
+
+        it('should throw error on empty enum array', () => {
+            const schema = {
+                title: 'Test input schema',
+                type: 'object',
+                schemaVersion: 1,
+                properties: {
+                    myField: {
+                        title: 'Field title',
+                        type: 'string',
+                        description: 'Some description ...',
+                        enum: [],
+                    },
+                },
+            };
+
+            expect(() => validateInputSchema(validator, schema)).toThrow(
+                'Input schema is not valid (Field schema.properties.myField.enum.enum must NOT have fewer than 1 items)',
+            );
+        });
+
+        it('should throw error on empty enumTitles array', () => {
+            const schema = {
+                title: 'Test input schema',
+                type: 'object',
+                schemaVersion: 1,
+                properties: {
+                    myField: {
+                        title: 'Field title',
+                        type: 'string',
+                        description: 'Some description ...',
+                        enum: ['abcd'],
+                        enumTitles: [],
+                    },
+                },
+            };
+
+            expect(() => validateInputSchema(validator, schema)).toThrow(
+                'Input schema is not valid (Field schema.properties.myField.enum.enumTitles must NOT have fewer than 1 items)',
             );
         });
 


### PR DESCRIPTION
Disallow empty enums in input schema, to make schemas like this invalid:
```jsonc
{
    // ...
    properties: {
        myField: {
            title: 'Field title',
            type: 'string',
            description: 'Some description',
            enum: []
        }
    }
};```