### PR TITLE
fix: omits node: import from events builtin module

### DIFF
--- a/packages/log/src/logger.ts
+++ b/packages/log/src/logger.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from 'events';
 import { LogLevel } from './log_consts';
 import { Exception } from './logger_text';
 


### PR DESCRIPTION
Sadly, node: builtin modules import doesn't work with meteor js, where we need to use this package.