### PR TITLE
feat: allow custom proxies to be https

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -56,7 +56,7 @@ export const APIFY_PROXY_VALUE_REGEX = /^[\w._~]+$/;
 // http://123123:qweqwe:asdasd@proxy.com:55555
 // http://proxy.apify.com:5000
 // http://root@proxy.apify.com:5000
-export const PROXY_URL_REGEX = /^http:\/\/(([^:]+:)?[^@]*@)?[^.:@]+\.[^:]+:[\d]+?$/;
+export const PROXY_URL_REGEX = /^https?:\/\/(([^:]+:)?[^@]*@)?[^.:@]+\.[^:]+:[\d]+?$/;
 
 /**
  * AWS S3 docs say:

--- a/packages/input_schema/src/intl.ts
+++ b/packages/input_schema/src/intl.ts
@@ -21,7 +21,7 @@ const intlStrings = {
     'inputSchema.validation.proxyGroupsNotAvailable':
         'You currently do not have access to proxy groups: {groups}',
     'inputSchema.validation.customProxyInvalid':
-        'Proxy URL "{invalidUrl}" has invalid format, it must be http://[username[:password]]@hostname:port.',
+        'Proxy URL "{invalidUrl}" has invalid format, it must be http[s]://[username[:password]]@hostname:port.',
     'inputSchema.validation.apifyProxyCountryInvalid':
         'Country code "{invalidCountry}" is invalid. Only ISO 3166-1 alpha-2 country codes are supported.',
     'inputSchema.validation.apifyProxyCountryWithoutApifyProxyForbidden':

--- a/test/utilities.client.test.ts
+++ b/test/utilities.client.test.ts
@@ -958,12 +958,12 @@ describe('utilities.client', () => {
             const proxy = null;
             const inputs = [
                 // Invalid
-                { field: { useApifyProxy: false, proxyUrls: ['https://asdasd:qweqe@proxy.apify.com:8000'] } }, // https
                 { field: { useApifyProxy: false, proxyUrls: ['http://asdasd:qweqe@proxy.apify.com'] } }, // missing port
                 { field: { useApifyProxy: false, proxyUrls: ['http://asdasd:qweqe@proxy.apify.com:8000/asd'] } }, // path after port
                 { field: { useApifyProxy: false, proxyUrls: ['http://asdasd@qweqe@proxy.apify.com:8000'] } }, // malformed url
                 { field: { useApifyProxy: false, proxyUrls: ['http://asdasd:qweqe:proxy.apify.com:8000'] } }, // malformed url
                 // Valid
+                { field: { useApifyProxy: false, proxyUrls: ['https://asdasd:qweqe@proxy.apify.com:8000'] } }, // https
                 { field: { useApifyProxy: false, proxyUrls: ['http://proxy.apify.com:8000'] } }, // without auth
                 { field: { useApifyProxy: false, proxyUrls: ['http://qweqe@proxy.apify.com:6000'] } }, // without password
                 { field: { useApifyProxy: false, proxyUrls: ['http://asd:qweqe@proxy.apify.com:55555'] } }, // with auth

--- a/test/utilities.client.test.ts
+++ b/test/utilities.client.test.ts
@@ -974,7 +974,7 @@ describe('utilities.client', () => {
                 .filter((errors) => errors.length > 0);
 
             // There should be 5 invalid inputs
-            expect(results.length).toEqual(5);
+            expect(results.length).toEqual(4);
             results.forEach((result) => {
                 // Only one error should be thrown
                 expect(result.length).toEqual(1);


### PR DESCRIPTION
Ondra needs to have custom proxy urls to allow https since he want's to test some provider proxies and they do not have http. He says it's working in crawlee, but our input schema does not allow it. I checked and it looks like this regex is only used for that one check.