### PR TITLE
feat: added multiselect option to input schema

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -36,6 +36,7 @@
                         { "$ref": "#/definitions/stringProperty" },
                         { "$ref": "#/definitions/stringEnumProperty" },
                         { "$ref": "#/definitions/arrayProperty" },
+                        { "$ref": "#/definitions/arrayEnumProperty"},
                         { "$ref": "#/definitions/objectProperty" },
                         { "$ref": "#/definitions/integerProperty" },
                         { "$ref": "#/definitions/booleanProperty" },
@@ -158,6 +159,45 @@
                 "sectionDescription": { "type": "string" }
             },
             "required": ["type", "title", "description", "editor"]
+        },
+
+        "arrayEnumProperty": {
+            "title": "Array enum property",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": { "enum": ["array"] },
+                "editor": { "enum": ["select"] },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "default": { "type": "array" },
+                "prefill": { "type": "array" },
+                "example": { "type": "array" },
+                "minItems": { "type": "integer" },
+                "maxItems": { "type": "integer" },
+                "uniqueItems": { "type": "boolean" },
+                "nullable": { "type": "boolean" },
+                "sectionCaption": { "type": "string" },
+                "sectionDescription": { "type": "string" },
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "type": { "enum": ["string"] },
+                        "enum": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "uniqueItems": true
+                        },
+                        "enumTitles": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        }
+                    },
+                    "required": ["type", "enum"]
+                }
+            },
+            "required": ["type", "editor", "title", "description", "items"]
         },
         "objectProperty": {
             "title": "Object property",


### PR DESCRIPTION
This adds the option for users to create multiselect input UI fields. We first need to merge this and then in apify-core update the input schema package in my second PR with the UI part and then update also worker to allow users to build actors with the new schema field.

The enum and enumTitles must be wrapped in items field sadly, instead of being directly on the property object, because that is the only way how json schema supports typing items of array.