### PR TITLE
feat: add more ACTOR_ env vars, add a test, rename ENV_VARS

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -251,7 +251,7 @@ export const REQUEST_QUEUE_HEAD_MAX_LIMIT = 1000;
 /**
  * Dictionary of APIFY_XXX environment variable names.
  */
-export const ENV_VARS = {
+export const APIFY_ENV_VARS = {
     IS_AT_HOME: 'APIFY_IS_AT_HOME',
     ACTOR_ID: 'APIFY_ACTOR_ID',
     ACTOR_RUN_ID: 'APIFY_ACTOR_RUN_ID',
@@ -298,19 +298,28 @@ export const ENV_VARS = {
 } as const;
 
 /**
+ * `ENV_VARS` were replaced by `APIFY_ENV_VARS`. We keep this for backwards compatibility.
+ */
+export const ENV_VARS = APIFY_ENV_VARS;
+
+/**
  * Dictionary of environment variable names prefixed with "ACTOR_".
  * Follows from Actor specs https://github.com/apify/actor-specs/#environment-variables
  */
 export const ACTOR_ENV_VARS = {
+    BUILD_ID: 'ACTOR_BUILD_ID',
+    BUILD_NUMBER: 'ACTOR_BUILD_NUMBER',
     DEFAULT_DATASET_ID: 'ACTOR_DEFAULT_DATASET_ID',
     DEFAULT_KEY_VALUE_STORE_ID: 'ACTOR_DEFAULT_KEY_VALUE_STORE_ID',
     DEFAULT_REQUEST_QUEUE_ID: 'ACTOR_DEFAULT_REQUEST_QUEUE_ID',
     EVENTS_WEBSOCKET_URL: 'ACTOR_EVENTS_WEBSOCKET_URL',
+    ID: 'ACTOR_ID',
     INPUT_KEY: 'ACTOR_INPUT_KEY',
     MAX_PAID_DATASET_ITEMS: 'ACTOR_MAX_PAID_DATASET_ITEMS',
     MEMORY_MBYTES: 'ACTOR_MEMORY_MBYTES',
     RUN_ID: 'ACTOR_RUN_ID',
     STARTED_AT: 'ACTOR_STARTED_AT',
+    TASK_ID: 'ACTOR_TASK_ID',
     TIMEOUT_AT: 'ACTOR_TIMEOUT_AT',
     WEB_SERVER_PORT: 'ACTOR_WEB_SERVER_PORT',
     WEB_SERVER_URL: 'ACTOR_WEB_SERVER_URL',

--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -298,7 +298,7 @@ export const APIFY_ENV_VARS = {
 } as const;
 
 /**
- * `ENV_VARS` were replaced by `APIFY_ENV_VARS`. We keep this for backwards compatibility.
+ * @deprecated `ENV_VARS` were replaced by `APIFY_ENV_VARS`. We currently keep this for backwards compatibility.
  */
 export const ENV_VARS = APIFY_ENV_VARS;
 

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -1,4 +1,4 @@
-import { USERNAME, APIFY_ID_REGEX } from '@apify/consts';
+import { USERNAME, APIFY_ID_REGEX, ACTOR_ENV_VARS, ENV_VARS, APIFY_ENV_VARS } from '@apify/consts';
 import { cryptoRandomObjectId } from '@apify/utilities';
 
 describe('consts', () => {
@@ -47,6 +47,22 @@ describe('consts', () => {
             for (let i = 0; i < 1000; i++) {
                 expect(cryptoRandomObjectId()).toMatch(APIFY_ID_REGEX);
             }
+        });
+    });
+
+    describe('ACTOR_ENV_VARS', () => {
+        it('every value begins with "ACTOR_"', () => {
+            Object.values(ACTOR_ENV_VARS).forEach((v) => {
+                expect(v.startsWith('ACTOR_')).toBe(true);
+            });
+        });
+    });
+
+    describe('APIFY_ENV_VARS', () => {
+        it('is the same as ENV_VARS', () => {
+            Object.keys(APIFY_ENV_VARS).forEach((k) => {
+                expect(APIFY_ENV_VARS[k]).toBe(ENV_VARS[k]);
+            });
         });
     });
 });

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -51,9 +51,9 @@ describe('consts', () => {
     });
 
     describe('ACTOR_ENV_VARS', () => {
-        it('every value begins with "ACTOR_"', () => {
-            Object.values(ACTOR_ENV_VARS).forEach((v) => {
-                expect(v.startsWith('ACTOR_')).toBe(true);
+        it('every value is "ACTOR_" + key', () => {
+            Object.entries(ACTOR_ENV_VARS).forEach(([k, v]) => {
+                expect(v).toBe(`ACTOR_${k}`);
             });
         });
     });

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -64,5 +64,14 @@ describe('consts', () => {
                 expect(APIFY_ENV_VARS[k]).toBe(ENV_VARS[k]);
             });
         });
+
+        it('every value is "APIFY_" + key', () => {
+            Object.entries(APIFY_ENV_VARS).forEach(([k, v]) => {
+                // TODO: remove this once ACTOR_MAX_PAID_DATASET_ITEMS is removed from APIFY_ENV_VARS
+                if (k === 'ACTOR_MAX_PAID_DATASET_ITEMS') return;
+
+                expect(v).toBe(`APIFY_${k}`);
+            });
+        });
     });
 });


### PR DESCRIPTION
I added more actor env vars based on updated https://github.com/apify/actor-specs/#environment-variables

I added a test that checks if all actor env vars begin with `ACTOR_`.

I renamed `ENV_VARS` to `APIFY_ENV_VARS` and created a new `ENV_VARS` variable that just copies the values for backwards compatibility. Also added a test to check if this works correctly.