### PR TITLE
feat: make @apify/log browser-compatible

### DIFF
--- a/packages/log/src/log_helpers.ts
+++ b/packages/log/src/log_helpers.ts
@@ -24,7 +24,7 @@ export function truncate(str: string, maxLength: number, suffix = '...[truncated
  * Gets log level from env variable. Both integers and strings (WARNING) are supported.
  */
 export function getLevelFromEnv(): number {
-    const envVar = process.env[APIFY_ENV_VARS.LOG_LEVEL];
+    const envVar = globalThis.process?.env[APIFY_ENV_VARS.LOG_LEVEL];
 
     if (!envVar) return LogLevel.INFO;
     if (Number.isFinite(+envVar)) return +envVar;
@@ -38,7 +38,7 @@ export function getLevelFromEnv(): number {
  * Defaults to 'TEXT' if no value is specified.
  */
 export function getFormatFromEnv(): LogFormat {
-    const envVar = process.env[APIFY_ENV_VARS.LOG_FORMAT] || LogFormat.TEXT;
+    const envVar = globalThis.process?.env[APIFY_ENV_VARS.LOG_FORMAT] || LogFormat.TEXT;
 
     switch (envVar.toLowerCase()) {
         case LogFormat.JSON.toLowerCase():

--- a/packages/log/src/logger_text.ts
+++ b/packages/log/src/logger_text.ts
@@ -80,8 +80,12 @@ export class LoggerText extends Logger {
         // NOTE: Reason is here to support Meteor.js like errors.
         const errorString = exception.stack || exception.reason || exception.toString();
         const errorLines = errorString.split('\n');
-        const causeString = exception.cause
-            ? inspect(exception.cause, { colors: true, maxArrayLength: 20 }) : null;
+        let causeString = null;
+
+        if (exception.cause) {
+            if (inspect) causeString = inspect(exception.cause, { colors: true, maxArrayLength: 20 });
+            else causeString = exception.cause.toString();
+        }
 
         // Add details to a first line.
         if (errDetails.length) errorLines[0] += c.gray(`(details: ${errDetails.join(', ')})`);


### PR DESCRIPTION
With these changes, `@apify/log` should run in a browser just fine... except for the `node:util` import, which has to be disabled with `webpack`'s `resolve.fallback.util: false`. Is there a better way of doing a conditional import (yeah, I know 🤮 ) to make this package browser-friendly? 

Closes #432