### PR TITLE
feat: log error causes (without breaking things this time)

### DIFF
--- a/packages/log/src/log.ts
+++ b/packages/log/src/log.ts
@@ -170,7 +170,7 @@ export class Log {
         if (level > this.options.level) return;
 
         data = { ...this.options.data, ...data };
-        data = Object.keys(data).length > 0 ? this._limitDepth(data) : undefined;
+        data = Reflect.ownKeys(data).length > 0 ? this._limitDepth(data) : undefined;
         exception = this._limitDepth(exception);
 
         this.options.logger.log(level, message, data, exception, {

--- a/packages/log/src/log_consts.ts
+++ b/packages/log/src/log_consts.ts
@@ -23,3 +23,9 @@ export const LEVELS = LogLevel;
 
 // Inverse of LOG_LEVELS = maps log level to string.
 export const LEVEL_TO_STRING = Object.keys(LogLevel).filter((x) => Number.isNaN(+x));
+
+/**
+ * A symbol used to mark a limited depth object as having come from an error
+ * @internal
+ */
+export const IS_APIFY_LOGGER_EXCEPTION = Symbol('apify.processed_error');

--- a/packages/log/src/log_helpers.ts
+++ b/packages/log/src/log_helpers.ts
@@ -64,7 +64,7 @@ export function limitDepth<T>(record: T, depth: number, maxStringLength?: number
         return maxStringLength && record.length > maxStringLength ? truncate(record, maxStringLength) as unknown as T : record;
     }
 
-    if (['number', 'boolean', 'symbol'].includes(typeof record) || record == null || record instanceof Date) {
+    if (['number', 'boolean', 'symbol', 'bigint'].includes(typeof record) || record == null || record instanceof Date) {
         return record;
     }
 

--- a/packages/log/src/log_helpers.ts
+++ b/packages/log/src/log_helpers.ts
@@ -1,5 +1,5 @@
 import { APIFY_ENV_VARS } from '@apify/consts';
-import { LogLevel, LogFormat } from './log_consts';
+import { LogLevel, LogFormat, IS_APIFY_LOGGER_EXCEPTION } from './log_consts';
 
 /**
  * Ensures a string is shorter than a specified number of character, and truncates it if not, appending a specific suffix to it.
@@ -64,15 +64,15 @@ export function limitDepth<T>(record: T, depth: number, maxStringLength?: number
         return maxStringLength && record.length > maxStringLength ? truncate(record, maxStringLength) as unknown as T : record;
     }
 
-    if (['number', 'boolean'].includes(typeof record) || record == null || record instanceof Date) {
+    if (['number', 'boolean', 'symbol'].includes(typeof record) || record == null || record instanceof Date) {
         return record;
     }
 
     // WORKAROUND: Error's properties are not iterable, convert it to a simple object and preserve custom properties
     // NOTE: _.isError() doesn't work on Match.Error
     if (record instanceof Error) {
-        const { name, message, stack, ...rest } = record;
-        record = { name, message, stack, ...rest } as unknown as T;
+        const { name, message, stack, cause, ...rest } = record;
+        record = { name, message, stack, cause, ...rest, [IS_APIFY_LOGGER_EXCEPTION]: true } as unknown as T;
     }
 
     const nextCall = (rec: T) => limitDepth(rec, depth - 1, maxStringLength);
@@ -84,7 +84,7 @@ export function limitDepth<T>(record: T, depth: number, maxStringLength?: number
     if (typeof record === 'object' && record !== null) {
         const mapObject = <U extends Record<PropertyKey, any>> (obj: U) => {
             const res = {} as U;
-            Object.keys(obj).forEach((key: keyof U) => {
+            Reflect.ownKeys(obj).forEach((key: keyof U) => {
                 res[key as keyof U] = nextCall(obj[key]) as U[keyof U];
             });
             return res;
@@ -103,4 +103,20 @@ export function limitDepth<T>(record: T, depth: number, maxStringLength?: number
     console.log(`WARNING: Object cannot be logged: ${record}`);
 
     return undefined;
+}
+
+// Like an error class, but turned into an object
+export interface LimitedError {
+    // used to identify this object as an error
+    [IS_APIFY_LOGGER_EXCEPTION]: true;
+    name: string;
+    message: string;
+    stack?: string;
+    cause?: unknown;
+
+    // Custom properties
+    type?: string;
+    details?: Record<string, unknown>;
+    reason?: string;
+    [key: string]: unknown;
 }

--- a/packages/log/src/logger.ts
+++ b/packages/log/src/logger.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { EventEmitter } from 'events';
 import { LogLevel } from './log_consts';
-import { Exception } from './logger_text';
 
 /**
  * This is an abstract class that should
@@ -39,7 +38,7 @@ export class Logger extends EventEmitter {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _log(level: LogLevel, message: string, data?: any, exception?: Exception, opts: Record<string, any> = {}) {
+    _log(level: LogLevel, message: string, data?: any, exception?: unknown, opts: Record<string, any> = {}) {
         throw new Error('log() method must be implemented!');
     }
 

--- a/packages/log/src/logger_json.ts
+++ b/packages/log/src/logger_json.ts
@@ -1,6 +1,5 @@
 import { PREFIX_DELIMITER, LogLevel } from './log_consts';
 import { Logger } from './logger';
-import { Exception } from './logger_text';
 
 const DEFAULT_OPTIONS = {
     skipLevelInfo: false,
@@ -12,7 +11,7 @@ export class LoggerJson extends Logger {
         super({ ...DEFAULT_OPTIONS, ...options });
     }
 
-    _log(level: LogLevel, message: string, data?: any, exception?: Exception, opts: Record<string, any> = {}) {
+    _log(level: LogLevel, message: string, data?: any, exception?: unknown, opts: Record<string, any> = {}) {
         const { prefix, suffix } = opts;
 
         if (exception) data = { ...data, exception };

--- a/packages/log/src/logger_text.ts
+++ b/packages/log/src/logger_text.ts
@@ -62,12 +62,17 @@ export class LoggerText extends Logger {
     }
 
     protected _parseException(exception: unknown, indentLevel = 1) {
-        if (!exception) {
-            return '';
+        if (['string', 'boolean', 'number', 'undefined', 'bigint'].includes(typeof exception)) {
+            return `\n${exception}`;
         }
 
-        if (['string', 'boolean', 'number', 'symbol', 'undefined'].includes(typeof exception)) {
-            return `\n${exception}`;
+        if (exception === null) {
+            return '\nnull';
+        }
+
+        // We need to manually call toString on symbols
+        if (typeof exception === 'symbol') {
+            return `\n${exception.toString()}`;
         }
 
         if (typeof exception === 'object' && IS_APIFY_LOGGER_EXCEPTION in exception) {

--- a/packages/log/src/node_internals.ts
+++ b/packages/log/src/node_internals.ts
@@ -64,7 +64,7 @@ export function getStackFrames(err: Error, stack: string) {
     }
 
     // Remove stack frames identical to frames in cause.
-    if (cause != null && IS_APIFY_LOGGER_EXCEPTION in (cause as any)) {
+    if (cause != null && typeof cause === 'object' && IS_APIFY_LOGGER_EXCEPTION in (cause as any)) {
         const causeStack = getStackString(cause);
         const causeStackStart = causeStack.indexOf('\n    at');
         if (causeStackStart !== -1) {

--- a/packages/log/src/node_internals.ts
+++ b/packages/log/src/node_internals.ts
@@ -1,0 +1,81 @@
+/*
+THE FOLLOWING CODE IS LICENSED UNDER THE FOLLOWING LICENSE:
+
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+*/
+
+// We've adapted the following code to work with our "error" representations (which are just nested simple objects)
+
+import c from 'ansi-colors';
+import { IS_APIFY_LOGGER_EXCEPTION } from './log_consts';
+
+function identicalSequenceRange(a: any[], b: any[]) {
+    for (let i = 0; i < a.length - 3; i++) {
+        // Find the first entry of b that matches the current entry of a.
+        const pos = b.indexOf(a[i]);
+        if (pos !== -1) {
+            const rest = b.length - pos;
+            if (rest > 3) {
+                let len = 1;
+                const maxLen = Math.min(a.length - i, rest);
+                // Count the number of consecutive entries.
+                while (maxLen > len && a[i + len] === b[pos + len]) {
+                    len++;
+                }
+                if (len > 3) {
+                    return { len, offset: i };
+                }
+            }
+        }
+    }
+
+    return { len: 0, offset: 0 };
+}
+
+function getStackString(error: any) {
+    return error.stack ? String(error.stack) : Error.prototype.toString.call(error);
+}
+
+export function getStackFrames(err: Error, stack: string) {
+    const frames = stack.split('\n');
+
+    let cause;
+    try {
+        ({ cause } = err);
+    } catch {
+    // If 'cause' is a getter that throws, ignore it.
+    }
+
+    // Remove stack frames identical to frames in cause.
+    if (cause != null && IS_APIFY_LOGGER_EXCEPTION in (cause as any)) {
+        const causeStack = getStackString(cause);
+        const causeStackStart = causeStack.indexOf('\n    at');
+        if (causeStackStart !== -1) {
+            const causeFrames = causeStack.slice(causeStackStart + 1).split('\n');
+            const { len, offset } = identicalSequenceRange(frames, causeFrames);
+            if (len > 0) {
+                const skipped = len - 2;
+                const msg = `    ... ${skipped} lines matching cause stack trace ...`;
+                frames.splice(offset + 1, skipped, c.grey(msg));
+            }
+        }
+    }
+    return frames;
+}

--- a/packages/utilities/src/exponential_backoff.ts
+++ b/packages/utilities/src/exponential_backoff.ts
@@ -1,17 +1,17 @@
-import log, { Exception } from '@apify/log';
+import log from '@apify/log';
 import { delayPromise } from './utilities';
 
 export class RetryableError extends Error {
-    readonly error: Exception;
+    readonly error: Error;
 
-    constructor(error: Error | Exception, ...args: unknown[]) {
+    constructor(error: Error, ...args: unknown[]) {
         super(...args as [string]);
-        this.error = error as Exception;
+        this.error = error;
     }
 }
 
 // extend the error with added properties
-export interface RetryableError extends Exception {}
+export interface RetryableError extends Error {}
 
 export async function retryWithExpBackoff<T>(
     params: { func?: (...args: unknown[]) => T, expBackoffMillis?: number, expBackoffMaxRepeats?: number } = {},
@@ -54,7 +54,7 @@ export async function retryWithExpBackoff<T>(
         if (i === Math.round(expBackoffMaxRepeats / 2)) {
             log.warning(`Retry failed ${i} times and will be repeated in ${randomizedWaitMillis}ms`, {
                 originalError: error.error.message,
-                errorDetails: error.error.details,
+                errorDetails: Reflect.get(error.error, 'details'),
             });
         }
 

--- a/test/exponential_backoff.test.ts
+++ b/test/exponential_backoff.test.ts
@@ -1,4 +1,4 @@
-import log, { Exception } from '@apify/log';
+import log from '@apify/log';
 import { retryWithExpBackoff, RetryableError } from '@apify/utilities';
 
 describe('exponential_backoff', () => {
@@ -103,11 +103,11 @@ describe('exponential_backoff', () => {
     it('should display correct message after 1/2 of retries', async () => {
         const logWarningSpy = jest.spyOn(log, 'warning');
 
-        let error!: Exception;
+        let error!: Error & { details?: Record<string, any> };
         try {
             await retryWithExpBackoff({
                 func: async () => {
-                    const err = new Error('Failed because of XXX') as Exception;
+                    const err = new Error('Failed because of XXX') as Error & { details?: Record<string, any> };
                     err.details = { foo: 'bar' };
                     throw new RetryableError(err);
                 },
@@ -115,7 +115,7 @@ describe('exponential_backoff', () => {
                 expBackoffMillis: 10,
             });
         } catch (e) {
-            error = e as Exception;
+            error = e as Error & { details?: Record<string, any> };
         }
         expect(error.message).toBe('Failed because of XXX');
         expect(error.details).toEqual({ foo: 'bar' });

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -190,5 +190,19 @@ describe('log', () => {
 
             expect(line).toMatch(new RegExp(pattern));
         });
+
+        it('should support printing cause even if it is not an error', () => {
+            const log = new Log({ logger: new LoggerText() });
+            const actualError = new Error('some error', { cause: 'hello world!' });
+
+            log.exception(actualError, 'Some error message');
+
+            expect(loggerSpy).toHaveBeenCalled();
+
+            const line = loggedLines.error;
+            const pattern = `^ERROR Some error message\\s+some error([\\s\\S]*)CAUSE: hello world!`;
+
+            expect(line).toMatch(new RegExp(pattern));
+        });
     }
 });

--- a/test/log_helpers.test.ts
+++ b/test/log_helpers.test.ts
@@ -1,4 +1,4 @@
-import { limitDepth, getLevelFromEnv, LogLevel } from '@apify/log';
+import { limitDepth, getLevelFromEnv, LogLevel, IS_APIFY_LOGGER_EXCEPTION } from '@apify/log';
 import { APIFY_ENV_VARS } from '@apify/consts';
 
 describe('getLevelFromEnv()', () => {
@@ -72,7 +72,7 @@ describe('limitDepth()', () => {
                 b: '[object]',
             },
             arr: [1, 2, '[object]'],
-            err: { name: err.name, message: err.message, stack: err.stack, ...err as any },
+            err: { name: err.name, message: err.message, stack: err.stack, ...err as any, cause: undefined, [IS_APIFY_LOGGER_EXCEPTION]: true },
         };
 
         expect(limitDepth(object, 2)).toEqual(limited);
@@ -137,6 +137,8 @@ describe('limitDepth()', () => {
             stack: error.stack,
             injectedArrow: '[function]',
             injectedFce: '[function]',
+            cause: undefined,
+            [IS_APIFY_LOGGER_EXCEPTION]: true,
         });
     });
 });


### PR DESCRIPTION
This is the proper reimplementation of https://github.com/apify/apify-shared-js/pull/428 & revert of https://github.com/apify/apify-shared-js/pull/434

![image](https://github.com/apify/apify-shared-js/assets/17960496/0a664bed-8775-4ec6-860b-679538e77646)

```ts
import log from '@apify/log';

const err = new Error('Some error');
const errWithCause = new Error('Some error with cause', { cause: err });
const errWithNestedCause = new Error('Some error with nested cause', { cause: errWithCause });

log.exception(errWithNestedCause);
```