### PR TITLE
feat: Remove @apify/consts private package dependency

### DIFF
--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -48,7 +48,6 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/consts": "^2.26.0",
         "ansi-colors": "^4.1.1"
     }
 }

--- a/packages/log/src/log_helpers.ts
+++ b/packages/log/src/log_helpers.ts
@@ -1,5 +1,12 @@
-import { APIFY_ENV_VARS } from '@apify/consts';
 import { LogLevel, LogFormat, IS_APIFY_LOGGER_EXCEPTION } from './log_consts';
+
+// This is a subset of APIFY_ENV_VARS, which we can't use directly to
+// avoid a dependency on the private package '@apify/consts' !
+// See https://apifier.slack.com/archives/C01VBUV81UZ/p1708427261484589 for context
+const ENV_VARS = {
+    LOG_LEVEL: 'APIFY_LOG_LEVEL',
+    LOG_FORMAT: 'APIFY_LOG_FORMAT',
+};
 
 /**
  * Ensures a string is shorter than a specified number of character, and truncates it if not, appending a specific suffix to it.
@@ -24,7 +31,7 @@ export function truncate(str: string, maxLength: number, suffix = '...[truncated
  * Gets log level from env variable. Both integers and strings (WARNING) are supported.
  */
 export function getLevelFromEnv(): number {
-    const envVar = process.env[APIFY_ENV_VARS.LOG_LEVEL];
+    const envVar = process.env[ENV_VARS.LOG_LEVEL];
 
     if (!envVar) return LogLevel.INFO;
     if (Number.isFinite(+envVar)) return +envVar;
@@ -38,7 +45,7 @@ export function getLevelFromEnv(): number {
  * Defaults to 'TEXT' if no value is specified.
  */
 export function getFormatFromEnv(): LogFormat {
-    const envVar = process.env[APIFY_ENV_VARS.LOG_FORMAT] || LogFormat.TEXT;
+    const envVar = process.env[ENV_VARS.LOG_FORMAT] || LogFormat.TEXT;
 
     switch (envVar.toLowerCase()) {
         case LogFormat.JSON.toLowerCase():
@@ -47,7 +54,7 @@ export function getFormatFromEnv(): LogFormat {
             return LogFormat.TEXT;
         default:
             // eslint-disable-next-line no-console
-            console.warn(`Unknown value for environment variable ${APIFY_ENV_VARS.LOG_FORMAT}: ${envVar}`);
+            console.warn(`Unknown value for environment variable ${ENV_VARS.LOG_FORMAT}: ${envVar}`);
             return LogFormat.TEXT;
     }
 }


### PR DESCRIPTION
@apify/consts is a private package, and thus the @apify/log package couldn't be used in public packages. This fixes it. See also https://apifier.slack.com/archives/C01VBUV81UZ/p1708427261484589