### PR TITLE
feat: improve linkedin profile regex

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -80,7 +80,7 @@ export const GITHUB_REGEX = new RegExp(`^${GITHUB_REGEX_STR}$`, 'i');
  * For matching linkedin URLs for both profiles and companies.
  * Used for validating urls in user settings.
  */
-export const LINKEDIN_PROFILE_REGEX = /^(https?:\/\/)?(www\.)?linkedin.com\/(in|company)\/([A-Za-z0-9]+)\/?$/;
+export const LINKEDIN_PROFILE_REGEX = /^(https?:\/\/)?(www\.)?([a-z]{2}\.)?linkedin.com\/(in|company)\/([A-Za-z0-9]+)\/?$/;
 
 /**
  * @deprecated Discontinue usage of this regexps, in favor of HTTP_URL_REGEX

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -291,8 +291,14 @@ const tests = {
     LINKEDIN_PROFILE_REGEX: {
         valid: [
             'https://www.linkedin.com/in/username',
+            'https://linkedin.com/in/username',
+            'http://linkedin.com/in/username',
             'https://www.linkedin.com/company/companyname',
-            'https://www.cs.linkedin.com/in/username/',
+            'https://linkedin.com/company/companyname',
+            'http://linkedin.com/company/companyname',
+            'https://www.cz.linkedin.com/in/username/',
+            'https://cz.linkedin.com/company/apifytech',
+            'http://cz.linkedin.com/company/apifytech',
         ],
         invalid: [
             'https://www.linkedin.com/in/',

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -288,6 +288,27 @@ const tests = {
             'https://127.0.0.1:3000',
         ],
     },
+    LINKEDIN_PROFILE_REGEX: {
+        valid: [
+            'https://www.linkedin.com/in/username',
+            'https://www.linkedin.com/company/companyname',
+            'https://www.cs.linkedin.com/in/username/',
+        ],
+        invalid: [
+            'https://www.linkedin.com/in/',
+            'https://www.linkedin.com/in',
+            'https://www.linkedin.com/company/',
+            'https://www.linkedin.com/company',
+            'https://www.linkedin.com/in/username/extra',
+            'https://www.linkedin.com/in/username/extra/',
+            'https://www.linkedin.com/company/companyname/extra',
+            'https://www.linkedin.com/company/companyname/extra/',
+            'https://www.linkedin.com/in/username/extra/extra',
+            'https://www.linkedin.com/in/username/extra/extra/',
+            'https://www.linkedin.com/company/companyname/extra/extra',
+            'https://www.linkedin.com/company/companyname/extra/extra/',
+        ],
+    },
 };
 
 describe('regexps', () => {


### PR DESCRIPTION
Should match profile links with eg `https://cs.linkedin.com`

Todo: bump version in core repo once this is merged...

Reported: https://apify.slack.com/archives/C0L33UM7Z/p1718628866387589