### PR TITLE
fix(consts): updated linkedin profile regex to support underscore and dash in the username

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -80,7 +80,7 @@ export const GITHUB_REGEX = new RegExp(`^${GITHUB_REGEX_STR}$`, 'i');
  * For matching linkedin URLs for both profiles and companies.
  * Used for validating urls in user settings.
  */
-export const LINKEDIN_PROFILE_REGEX = /^(https?:\/\/)?(www\.)?([a-z]{2}\.)?linkedin.com\/(in|company)\/([A-Za-z0-9]+)\/?$/;
+export const LINKEDIN_PROFILE_REGEX = /^(https?:\/\/)?(www\.)?([a-z]{2}\.)?linkedin.com\/(in|company)\/([A-Za-z0-9_-]+)\/?$/;
 
 /**
  * @deprecated Discontinue usage of this regexps, in favor of HTTP_URL_REGEX

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -291,6 +291,8 @@ const tests = {
     LINKEDIN_PROFILE_REGEX: {
         valid: [
             'https://www.linkedin.com/in/username',
+            'https://www.linkedin.com/in/user-name',
+            'https://www.linkedin.com/in/user_name',
             'https://linkedin.com/in/username',
             'http://linkedin.com/in/username',
             'https://www.linkedin.com/company/companyname',


### PR DESCRIPTION
LinkedIn supports creating usernames with dashes and underscores so we should also allow it with our form validation

Reported in the [#bug channel](https://apify.slack.com/archives/C0L33UM7Z/p1719817208470629)
