### PR TITLE
feat: add input schema type

### DIFF
--- a/packages/input_schema/src/index.ts
+++ b/packages/input_schema/src/index.ts
@@ -8,8 +8,6 @@ export {
     ArrayFieldDefinition,
     MixedFieldDefinition,
     FieldDefinition,
-    FieldDefinitionUnchecked,
     InputSchema,
-    InputSchemaUnchecked,
 } from './types';
 export * from './utilities';

--- a/packages/input_schema/src/index.ts
+++ b/packages/input_schema/src/index.ts
@@ -1,3 +1,15 @@
 export * from './intl';
 export * from './input_schema';
+export {
+    StringFieldDefinition,
+    BooleanFieldDefinition,
+    IntegerFieldDefinition,
+    ObjectFieldDefinition,
+    ArrayFieldDefinition,
+    MixedFieldDefinition,
+    FieldDefinition,
+    FieldDefinitionUnchecked,
+    InputSchema,
+    InputSchemaUnchecked,
+} from './types';
 export * from './utilities';

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -2,38 +2,41 @@ type CommonFieldDefinition<T> = {
     title: string;
     description: string;
     default?: T;
-    prefill?: T extends boolean ? never : T;
+    prefill?: T;
     example?: T;
     nullable?: boolean;
     sectionCaption?: string;
     sectionDescription?: string;
 }
 
-export type StringFieldDefinition = CommonFieldDefinition<string> & { type: 'string' } & {
-    // json is specified in tests, but not in docs
+export type StringFieldDefinition = CommonFieldDefinition<string> & {
+    type: 'string'
     editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json';
     pattern?: string;
     minLength?: number;
     maxLength?: number;
-    enum?: string[]; // required if editor is 'select'
-    enumTitles?: string[]
+    enum?: readonly string[]; // required if editor is 'select'
+    enumTitles?: readonly string[]
     isSecret?: boolean;
 }
 
-export type BooleanFieldDefinition = CommonFieldDefinition<boolean> & { type: 'boolean' } & {
+export type BooleanFieldDefinition = CommonFieldDefinition<boolean> & {
+    type: 'boolean'
     editor?: 'checkbox' | 'hidden';
     groupCaption?: string;
     groupDescription?: string;
 }
 
-export type IntegerFieldDefinition = CommonFieldDefinition<number> & { type: 'integer' } & {
+export type IntegerFieldDefinition = CommonFieldDefinition<number> & {
+    type: 'integer'
     editor?: 'number' | 'hidden';
     maximum?: number;
     minimum?: number;
     unit?: string;
 }
 
-export type ObjectFieldDefinition = CommonFieldDefinition<object> & { type: 'object' } & {
+export type ObjectFieldDefinition = CommonFieldDefinition<object> & {
+    type: 'object'
     editor: 'json' | 'proxy' | 'hidden';
     patternKey?: string;
     patternValue?: string;
@@ -41,7 +44,8 @@ export type ObjectFieldDefinition = CommonFieldDefinition<object> & { type: 'obj
     minProperties?: number;
 }
 
-export type ArrayFieldDefinition = CommonFieldDefinition<Array<unknown>> & { type: 'array' } & {
+export type ArrayFieldDefinition = CommonFieldDefinition<Array<unknown>> & {
+    type: 'array'
     editor: 'json' | 'requestListSources' | 'pseudoUrls' | 'globs' | 'keyValue' | 'stringList' | 'select' | 'hidden';
     placeholderKey?: string;
     placeholderValue?: string;
@@ -60,7 +64,7 @@ type AllTypes = StringFieldDefinition['type']
     | ArrayFieldDefinition['type']
 
 export type MixedFieldDefinition = CommonFieldDefinition<never> & {
-    type: AllTypes[] | readonly AllTypes[];
+    type: readonly AllTypes[];
     editor: 'json'
 }
 
@@ -82,12 +86,12 @@ export type InputSchemaBaseChecked = Omit<InputSchema, 'properties'> & {
  * Type with checked base & properties
  */
 export type InputSchema = {
+    type: 'object';
     title: string;
     description?: string;
-    type: 'object';
     schemaVersion: number;
     properties: Record<string, FieldDefinition>;
-    required: string[];
+    required?: readonly string[];
 
-    $schema: unknown;
+    $schema?: unknown;
 }

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -75,7 +75,7 @@ export type FieldDefinition = StringFieldDefinition
 type NeverFieldDefinition = CommonFieldDefinition<never> & { type?: undefined, editor?: string }
 
 type FieldDefinitionToUnchecked<T extends FieldDefinition | NeverFieldDefinition> = Partial<
-    Omit<T, 'type'> & { type: string | string[] }
+    Omit<T, 'type'> & { type: string | string[] | readonly string[] }
 >
 
 // needs to be separated to have all possible values

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -71,34 +71,11 @@ export type FieldDefinition = StringFieldDefinition
     | ArrayFieldDefinition
     | MixedFieldDefinition
 
-// should not be present, this type is for invalid schema
-type NeverFieldDefinition = CommonFieldDefinition<never> & { type?: undefined, editor?: string }
-
-type FieldDefinitionToUnchecked<T extends FieldDefinition | NeverFieldDefinition> = Partial<
-    Omit<T, 'type'> & { type: string | string[] | readonly string[] }
->
-
-// needs to be separated to have all possible values
-export type FieldDefinitionUnchecked = FieldDefinitionToUnchecked<StringFieldDefinition>
-    | FieldDefinitionToUnchecked<BooleanFieldDefinition>
-    | FieldDefinitionToUnchecked<IntegerFieldDefinition>
-    | FieldDefinitionToUnchecked<ObjectFieldDefinition>
-    | FieldDefinitionToUnchecked<ArrayFieldDefinition>
-    | FieldDefinitionToUnchecked<MixedFieldDefinition>
-    | FieldDefinitionToUnchecked<NeverFieldDefinition>;
-
-/**
- * Unchecked type for input schema that is parsed from JSON.
- */
-export type InputSchemaUnchecked = Partial<Omit<InputSchemaBaseChecked, 'type'>> & {
-    type: string
-}
-
 /**
  * Type with checked base, but not properties
  */
 export type InputSchemaBaseChecked = Omit<InputSchema, 'properties'> & {
-    properties: Record<string, FieldDefinitionUnchecked>;
+    properties: Record<string, Record<string, unknown>>;
 }
 
 /**

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -53,8 +53,14 @@ export type ArrayFieldDefinition = CommonFieldDefinition<Array<unknown>> & { typ
     items?: unknown;
 }
 
+type AllTypes = StringFieldDefinition['type']
+    | BooleanFieldDefinition['type']
+    | IntegerFieldDefinition['type']
+    | ObjectFieldDefinition['type']
+    | ArrayFieldDefinition['type']
+
 export type MixedFieldDefinition = CommonFieldDefinition<never> & {
-    type: ('string' | 'boolean' | 'integer' | 'object' | 'array')[];
+    type: AllTypes[] | readonly AllTypes[];
     editor: 'json'
 }
 
@@ -68,9 +74,11 @@ export type FieldDefinition = StringFieldDefinition
 // should not be present, this type is for invalid schema
 type NeverFieldDefinition = CommonFieldDefinition<never> & { type?: undefined, editor?: string }
 
-type FieldDefinitionToUnchecked<T extends FieldDefinition | NeverFieldDefinition> = Pick<T, 'type'> & Partial<T>
+type FieldDefinitionToUnchecked<T extends FieldDefinition | NeverFieldDefinition> = Partial<
+    Omit<T, 'type'> & { type: string | string[] }
+>
 
-// needs to be separated to stay discriminating union
+// needs to be separated to have all possible values
 export type FieldDefinitionUnchecked = FieldDefinitionToUnchecked<StringFieldDefinition>
     | FieldDefinitionToUnchecked<BooleanFieldDefinition>
     | FieldDefinitionToUnchecked<IntegerFieldDefinition>
@@ -82,12 +90,14 @@ export type FieldDefinitionUnchecked = FieldDefinitionToUnchecked<StringFieldDef
 /**
  * Unchecked type for input schema that is parsed from JSON.
  */
-export type InputSchemaUnchecked = Partial<InputSchemaBaseChecked>
+export type InputSchemaUnchecked = Partial<Omit<InputSchemaBaseChecked, 'type'>> & {
+    type: string
+}
 
 /**
  * Type with checked base, but not properties
  */
-export type InputSchemaBaseChecked = InputSchema & {
+export type InputSchemaBaseChecked = Omit<InputSchema, 'properties'> & {
     properties: Record<string, FieldDefinitionUnchecked>;
 }
 

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -1,0 +1,106 @@
+type CommonFieldDefinition<T> = {
+    title: string;
+    description: string;
+    default?: T;
+    prefill?: T extends boolean ? never : T;
+    example?: T;
+    nullable?: boolean;
+    sectionCaption?: string;
+    sectionDescription?: string;
+}
+
+export type StringFieldDefinition = CommonFieldDefinition<string> & { type: 'string' } & {
+    // json is specified in tests, but not in docs
+    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json';
+    pattern?: string;
+    minLength?: number;
+    maxLength?: number;
+    enum?: string[]; // required if editor is 'select'
+    enumTitles?: string[]
+    isSecret?: boolean;
+}
+
+export type BooleanFieldDefinition = CommonFieldDefinition<boolean> & { type: 'boolean' } & {
+    editor?: 'checkbox' | 'hidden';
+    groupCaption?: string;
+    groupDescription?: string;
+}
+
+export type IntegerFieldDefinition = CommonFieldDefinition<number> & { type: 'integer' } & {
+    editor?: 'number' | 'hidden';
+    maximum?: number;
+    minimum?: number;
+    unit?: string;
+}
+
+export type ObjectFieldDefinition = CommonFieldDefinition<object> & { type: 'object' } & {
+    editor: 'json' | 'proxy' | 'hidden';
+    patternKey?: string;
+    patternValue?: string;
+    maxProperties?: number;
+    minProperties?: number;
+}
+
+export type ArrayFieldDefinition = CommonFieldDefinition<Array<unknown>> & { type: 'array' } & {
+    editor: 'json' | 'requestListSources' | 'pseudoUrls' | 'globs' | 'keyValue' | 'stringList' | 'select' | 'hidden';
+    placeholderKey?: string;
+    placeholderValue?: string;
+    patternKey?: string;
+    patternValue?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    items?: unknown;
+}
+
+export type MixedFieldDefinition = CommonFieldDefinition<never> & {
+    type: ('string' | 'boolean' | 'integer' | 'object' | 'array')[];
+    editor: 'json'
+}
+
+export type FieldDefinition = StringFieldDefinition
+    | BooleanFieldDefinition
+    | IntegerFieldDefinition
+    | ObjectFieldDefinition
+    | ArrayFieldDefinition
+    | MixedFieldDefinition
+
+// should not be present, this type is for invalid schema
+type NeverFieldDefinition = CommonFieldDefinition<never> & { type?: undefined, editor?: string }
+
+type FieldDefinitionToUnchecked<T extends FieldDefinition | NeverFieldDefinition> = Pick<T, 'type'> & Partial<T>
+
+// needs to be separated to stay discriminating union
+export type FieldDefinitionUnchecked = FieldDefinitionToUnchecked<StringFieldDefinition>
+    | FieldDefinitionToUnchecked<BooleanFieldDefinition>
+    | FieldDefinitionToUnchecked<IntegerFieldDefinition>
+    | FieldDefinitionToUnchecked<ObjectFieldDefinition>
+    | FieldDefinitionToUnchecked<ArrayFieldDefinition>
+    | FieldDefinitionToUnchecked<MixedFieldDefinition>
+    | FieldDefinitionToUnchecked<NeverFieldDefinition>;
+
+/**
+ * Unchecked type for input schema that is parsed from JSON.
+ */
+export type InputSchemaUnchecked = Partial<InputSchemaBaseChecked>
+
+/**
+ * Type with checked base, but not properties
+ */
+export type InputSchemaBaseChecked = InputSchema & {
+    properties: Record<string, FieldDefinitionUnchecked>;
+}
+
+/**
+ * Type with checked base & properties
+ */
+export type InputSchema = {
+    title: string;
+    description?: string;
+    type: 'object';
+    schemaVersion: number;
+    properties: Record<string, FieldDefinition>;
+    required: string[];
+
+    $schema: unknown;
+}


### PR DESCRIPTION
I created an `InputSchema` type, mainly based on our documentation and also usage and tests. I am not sure if there is anything else that could be present or if `$schema` also should have been typed.

I tried to stay as backward compatible as possible.