### PR TITLE
feat(input_schema): storage editor types

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -86,7 +86,7 @@
                 "title": { "type": "string" },
                 "description": { "type": "string" },
                 "nullable": { "type": "boolean" },
-                "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden"] },
+                "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden", "dataset", "keyValueStore", "requestQueue"] },
                 "isSecret": { "type": "boolean" }
             },
             "required": ["type", "title", "description", "editor"],
@@ -112,7 +112,7 @@
                     "nullable": { "type": "boolean" },
                     "minLength": { "type": "integer" },
                     "maxLength": { "type": "integer" },
-                    "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden"] },
+                    "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden", "dataset", "keyValueStore", "requestQueue"] },
                     "isSecret": { "type": "boolean" },
                     "sectionCaption": { "type": "string" },
                     "sectionDescription": { "type": "string" }

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -11,7 +11,7 @@ type CommonFieldDefinition<T> = {
 
 export type StringFieldDefinition = CommonFieldDefinition<string> & {
     type: 'string'
-    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json';
+    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json' | 'dataset' | 'keyValueStore' | 'requestQueue';
     pattern?: string;
     minLength?: number;
     maxLength?: number;

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -156,7 +156,7 @@ describe('input_schema.json', () => {
 
             expect(() => validateInputSchema(validator, schema)).toThrow(
                 'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values: '
-                + '"javascript", "python", "textfield", "textarea", "datepicker", "hidden")',
+                + '"javascript", "python", "textfield", "textarea", "datepicker", "hidden", "dataset", "keyValueStore", "requestQueue")',
             );
         });
 


### PR DESCRIPTION
This PR introduce new input schema `editor` values for `string` property:
`dataset`, `keyValueStore` and `requestQueue` based on issue: https://github.com/apify/apify-core/issues/12871

The editor will show storage inputs enabling users to search and select storage, then the storage id is taken as field value.
Input PR waiting for this: https://github.com/apify/apify-core/pull/17521
Docs PR: https://github.com/apify/apify-docs/pull/1211

<img width="827" alt="Screenshot 2024-09-12 at 8 34 00" src="https://github.com/user-attachments/assets/bbac3103-67fe-4fff-8533-57bfe405247b">
