### PR TITLE
feat(consts): increase input schema max size to 500 kB

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -204,7 +204,7 @@ export const ACTOR_LIMITS = {
     MAX_RUN_MEMORY_MBYTES: 32768,
 
     // Maximum size of actor input schema.
-    INPUT_SCHEMA_MAX_BYTES: 200 * 1024,
+    INPUT_SCHEMA_MAX_BYTES: 500 * 1024,
 
     // Max length of run/build log in number of characters
     LOG_MAX_CHARS: 10 * 1024 * 1024,


### PR DESCRIPTION
This will need to bubble through to the Console and worker after it's merged to become effective.