### PR TITLE
fix(input_schema): disable isSecret for array properties

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -174,19 +174,7 @@
             "type": "object",
             "properties": {
                 "type": { "enum": ["array"] },
-                "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "select", "hidden"] },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "default": { "type": "array" },
-                "prefill": { "type": "array" },
-                "example": { "type": "array" },
-                "nullable": { "type": "boolean" },
-                "minItems": { "type": "integer" },
-                "maxItems": { "type": "integer" },
-                "uniqueItems": { "type": "boolean" },
-
-                "sectionCaption": { "type": "string" },
-                "sectionDescription": { "type": "string" }
+                "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "select", "hidden"] }
             },
             "additionalProperties": true,
             "required": ["type", "title", "description", "editor"],
@@ -196,8 +184,22 @@
                 }
             },
             "then": {
+                "additionalProperties": false,
                 "required": ["items"],
                 "properties": {
+                    "type": { "enum": ["array"] },
+                    "editor": { "enum": ["select"] },
+                    "title": { "type": "string" },
+                    "description": { "type": "string" },
+                    "default": { "type": "array" },
+                    "prefill": { "type": "array" },
+                    "example": { "type": "array" },
+                    "nullable": { "type": "boolean" },
+                    "minItems": { "type": "integer" },
+                    "maxItems": { "type": "integer" },
+                    "uniqueItems": { "type": "boolean" },
+                    "sectionCaption": { "type": "string" },
+                    "sectionDescription": { "type": "string" },
                     "items": {
                         "type": "object",
                         "additionalProperties": false,
@@ -218,7 +220,21 @@
                 }
             },
             "else": {
+                "additionalProperties": false,
                 "properties": {
+                    "type": { "enum": ["array"] },
+                    "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "hidden"] },
+                    "title": { "type": "string" },
+                    "description": { "type": "string" },
+                    "default": { "type": "array" },
+                    "prefill": { "type": "array" },
+                    "example": { "type": "array" },
+                    "nullable": { "type": "boolean" },
+                    "minItems": { "type": "integer" },
+                    "maxItems": { "type": "integer" },
+                    "uniqueItems": { "type": "boolean" },
+                    "sectionCaption": { "type": "string" },
+                    "sectionDescription": { "type": "string" },
                     "placeholderKey": { "type": "string" },
                     "placeholderValue": { "type": "string" },
                     "patternKey": { "type": "string" },

--- a/test/input_schema_definition.test.ts
+++ b/test/input_schema_definition.test.ts
@@ -235,6 +235,20 @@ describe('input_schema.json', () => {
                 });
             });
 
+            it('should allow only string type', () => {
+                [{ type: 'string', editor: 'textfield' }].forEach((fields) => {
+                    expect(isSchemaValid(fields, true)).toBe(true);
+                });
+                [
+                    { type: 'array', editor: 'stringList' },
+                    { type: 'object', editor: 'json' },
+                    { type: 'boolean' },
+                    { type: 'integer' },
+                ].forEach((fields) => {
+                    expect(isSchemaValid(fields, true)).toBe(false);
+                });
+            });
+
             it('should not allow some fields', () => {
                 ['minLength', 'maxLength'].forEach((intField) => {
                     expect(isSchemaValid({ [intField]: 10 }, true)).toBe(false);


### PR DESCRIPTION
Solves: https://github.com/apify/apify-core/issues/15613
The issue was with `arrayProperty` because it enables additional properties (`"additionalProperties": true`) so not defined properties were accepted including `isSecret`.

This PR fixes `arrayProperty` ensuring that not defined properties are prohibited

Adding also missing test that check this