### PR TITLE
feat(consts): introduce profile name (first, last, organization, ...) restrictions and adjust username regex

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -134,7 +134,7 @@ export const PROFILE_NAME = {
     MAX_LENGTH: 50,
 
     // Regex to prohibit anything that could potentially form an URL or email address.
-    REGEX: /^[^/.@><]{3,50}$/,
+    REGEX: /^[^/.@><]*$/,
 };
 
 /**

--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -116,7 +116,7 @@ export const USERNAME = {
 
     // Regex matching a potentially allowed username. The numbers must match MIN and MAX!
     // Note that username must also pass isForbiddenUser() test to be allowed!
-    REGEX: /^[a-zA-Z0-9_-]{3,30}$/,
+    REGEX: /^[a-zA-Z0-9_.-]{3,30}$/,
 };
 
 export const EMAIL = {
@@ -133,8 +133,8 @@ export const PROFILE_NAME = {
     MIN_LENGTH: 3,
     MAX_LENGTH: 50,
 
-    // Regex to prohibit anything that could potentially form an URL or email address.
-    REGEX: /^[^/.@><]*$/,
+    // Prohibits usage of @, <, > and :// in the name
+    REGEX: /^(?!.*:\/\/)[^@><]*$/,
 };
 
 /**

--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -1,4 +1,4 @@
-import { DNS_SAFE_NAME_REGEX } from './regexs';
+import { DNS_SAFE_NAME_REGEX, EMAIL_REGEX } from './regexs';
 
 export const FREE_SUBSCRIPTION_PLAN_CODE = 'DEV';
 
@@ -117,6 +117,13 @@ export const USERNAME = {
     // Regex matching a potentially allowed username. The numbers must match MIN and MAX!
     // Note that username must also pass isForbiddenUser() test to be allowed!
     REGEX: /^[a-zA-Z0-9_-]{3,30}$/,
+};
+
+export const EMAIL = {
+    MIN_LENGTH: 3,
+    MAX_LENGTH: 254, // see https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+
+    REGEX: EMAIL_REGEX,
 };
 
 /**

--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -98,6 +98,11 @@ export const ACTOR_TYPES = {
 } as const;
 
 /**
+ * Used as username for returning user own info from API v2/users/username
+ */
+export const ME_USER_NAME_PLACEHOLDER = 'me';
+
+/**
  * Username used when user is anonymous.
  */
 export const ANONYMOUS_USERNAME = 'anonymous';
@@ -111,7 +116,18 @@ export const USERNAME = {
 
     // Regex matching a potentially allowed username. The numbers must match MIN and MAX!
     // Note that username must also pass isForbiddenUser() test to be allowed!
-    REGEX: /^[a-zA-Z0-9_.-]{3,30}$/,
+    REGEX: /^[a-zA-Z0-9_-]{3,30}$/,
+};
+
+/**
+ * Profile name (such as organization or first / last name) constraints.
+ */
+export const PROFILE_NAME = {
+    MIN_LENGTH: 3,
+    MAX_LENGTH: 50,
+
+    // Regex to prohibit anything that could potentially form an URL or email address.
+    REGEX: /^[^/.@><]{3,50}$/,
 };
 
 /**
@@ -238,11 +254,6 @@ export const DEFAULT_PLATFORM_LIMITS = {
     // Maximum number of tasks per scheduler
     MAX_TASKS_PER_SCHEDULER: 10,
 };
-
-/**
- * Use as username for returning user own info from API v2/users/username
- */
-export const ME_USER_NAME_PLACEHOLDER = 'me';
 
 /**
  * Max length of the queue head that server will return in Request Queue API.

--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -120,9 +120,7 @@ export const USERNAME = {
 };
 
 export const EMAIL = {
-    MIN_LENGTH: 3,
     MAX_LENGTH: 254, // see https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
-
     REGEX: EMAIL_REGEX,
 };
 
@@ -130,11 +128,8 @@ export const EMAIL = {
  * Profile name (such as organization or first / last name) constraints.
  */
 export const PROFILE_NAME = {
-    MIN_LENGTH: 3,
     MAX_LENGTH: 50,
-
-    // Prohibits usage of @, <, > and :// in the name
-    REGEX: /^(?!.*:\/\/)[^@><]*$/,
+    REGEX: /^(?!.*:\/\/)[^@><]*$/, // Prohibits usage of @, <, > and ://
 };
 
 /**

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -6,12 +6,9 @@ describe('consts', () => {
         it('REGEX works as expected', () => {
             expect(USERNAME.REGEX.test('anonymous')).toBe(true);
             expect(USERNAME.REGEX.test('---')).toBe(true);
-            expect(USERNAME.REGEX.test('john.doe')).toBe(true);
             expect(USERNAME.REGEX.test('john')).toBe(true);
             expect(USERNAME.REGEX.test('john-doe')).toBe(true);
             expect(USERNAME.REGEX.test('JOHN_doe')).toBe(true);
-            expect(USERNAME.REGEX.test('favicon.icox')).toBe(true);
-            expect(USERNAME.REGEX.test('xfavicon.ico')).toBe(true);
             expect(USERNAME.REGEX.test('karl12345')).toBe(true);
             expect(USERNAME.REGEX.test('45678')).toBe(true);
         });

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -1,4 +1,14 @@
-import { USERNAME, APIFY_ID_REGEX, ACTOR_ENV_VARS, ENV_VARS, APIFY_ENV_VARS, LOCAL_ACTOR_ENV_VARS, LOCAL_APIFY_ENV_VARS, LOCAL_ENV_VARS } from '@apify/consts';
+import {
+    USERNAME,
+    APIFY_ID_REGEX,
+    ACTOR_ENV_VARS,
+    ENV_VARS,
+    APIFY_ENV_VARS,
+    LOCAL_ACTOR_ENV_VARS,
+    LOCAL_APIFY_ENV_VARS,
+    LOCAL_ENV_VARS,
+    PROFILE_NAME,
+} from '@apify/consts';
 import { cryptoRandomObjectId } from '@apify/utilities';
 
 describe('consts', () => {
@@ -6,11 +16,38 @@ describe('consts', () => {
         it('REGEX works as expected', () => {
             expect(USERNAME.REGEX.test('anonymous')).toBe(true);
             expect(USERNAME.REGEX.test('---')).toBe(true);
+            expect(USERNAME.REGEX.test('john.doe')).toBe(true);
             expect(USERNAME.REGEX.test('john')).toBe(true);
             expect(USERNAME.REGEX.test('john-doe')).toBe(true);
             expect(USERNAME.REGEX.test('JOHN_doe')).toBe(true);
+            expect(USERNAME.REGEX.test('favicon.icox')).toBe(true);
+            expect(USERNAME.REGEX.test('xfavicon.ico')).toBe(true);
             expect(USERNAME.REGEX.test('karl12345')).toBe(true);
             expect(USERNAME.REGEX.test('45678')).toBe(true);
+        });
+    });
+
+    describe('PROFILE_NAME', () => {
+        it('REGEX works as expected', () => {
+            // Valid cases
+            expect(PROFILE_NAME.REGEX.test('John Doe')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('Anonymous')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('John123')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('John-Doe')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('Org_Example')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test(':/JohnDoe')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test(':/a/Simple.Name')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('John:/Doe/')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('Simple:.//Name')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('Joh////:/n-Doe')).toBe(true);
+            expect(PROFILE_NAME.REGEX.test('user:name')).toBe(true);
+
+            // Invalid cases
+            expect(PROFILE_NAME.REGEX.test('user@name')).toBe(false);
+            expect(PROFILE_NAME.REGEX.test('user>name')).toBe(false);
+            expect(PROFILE_NAME.REGEX.test('user<name')).toBe(false);
+            expect(PROFILE_NAME.REGEX.test('example://test')).toBe(false);
+            expect(PROFILE_NAME.REGEX.test('example://////test')).toBe(false);
         });
     });
 


### PR DESCRIPTION
Affects https://github.com/apify/apify-core/issues/17545

Besides introduction of new Profile name restrictions, this also adjusts restrictions (regex) of valid username.
It does so to prevent users from inputing viable url addresses by removing a dot from allowed characters. By doing so, the username now cannot form a valid URL or Email domain.
See comment bellow for more info (@baldasseva mainly).