### PR TITLE
feat(utilities): markedSetNofollowLinks with hostname check

### DIFF
--- a/packages/utilities/src/utilities.client.ts
+++ b/packages/utilities/src/utilities.client.ts
@@ -158,9 +158,9 @@ export function normalizeUrl(url: string, keepFragment?: boolean) {
 }
 
 // Helper function for markdown rendered marked
-// If passed hostname, it renders links outside that hostname in readme with rel="noopener noreferrer" and target="_blank" attributes
+// If passed referrerHostname, it renders links outside that hostname in readme with rel="noopener noreferrer" and target="_blank" attributes
 // And links outside apify.com in readme with rel="noopener noreferrer nofollow" and target="_blank" attributes
-export function markedSetNofollowLinks(href: string, title: string, text: string, hostname?: string) {
+export function markedSetNofollowLinks(href: string, title: string, text: string, referrerHostname?: string) {
     let urlParsed: URL;
     try {
         urlParsed = new URL(href);
@@ -168,7 +168,7 @@ export function markedSetNofollowLinks(href: string, title: string, text: string
         // Probably invalid url, go on
     }
     const isApifyLink = (urlParsed! && /(\.|^)apify\.com$/i.test(urlParsed.hostname));
-    const isSameHostname = !hostname || (urlParsed! && urlParsed.hostname === hostname);
+    const isSameHostname = !referrerHostname || (urlParsed! && urlParsed.hostname === referrerHostname);
 
     if (isApifyLink && isSameHostname) {
         return `<a href="${href}">${title || text}</a>`;

--- a/packages/utilities/src/utilities.client.ts
+++ b/packages/utilities/src/utilities.client.ts
@@ -159,7 +159,7 @@ export function normalizeUrl(url: string, keepFragment?: boolean) {
 
 // Helper function for markdown rendered marked
 // Renders links outside apify.com in readme with rel="noopener noreferrer nofollow" and target="_blank" attributes
-export function markedSetNofollowLinks(href: string, title: string, text: string) {
+export function markedSetNofollowLinks(href: string, title: string, text: string, hostname?: string) {
     let urlParsed: URL;
     try {
         urlParsed = new URL(href);
@@ -167,9 +167,15 @@ export function markedSetNofollowLinks(href: string, title: string, text: string
         // Probably invalid url, go on
     }
     const isApifyLink = (urlParsed! && /(\.|^)apify\.com$/i.test(urlParsed.hostname));
-    return (isApifyLink)
-        ? `<a href="${href}">${title || text}</a>`
-        : `<a rel="noopener noreferrer nofollow" target="_blank" href="${href}">${title || text}</a>`;
+    const isSameHostname = !hostname || (urlParsed! && urlParsed.hostname === hostname);
+
+    if (isApifyLink && isSameHostname) {
+        return `<a href="${href}">${title || text}</a>`;
+    } if (isApifyLink) {
+        return `<a rel="noopener noreferrer" target="_blank" href="${href}">${title || text}</a>`;
+    }
+
+    return `<a rel="noopener noreferrer nofollow" target="_blank" href="${href}">${title || text}</a>`;
 }
 
 // Helper function for markdown rendered marked

--- a/packages/utilities/src/utilities.client.ts
+++ b/packages/utilities/src/utilities.client.ts
@@ -158,7 +158,8 @@ export function normalizeUrl(url: string, keepFragment?: boolean) {
 }
 
 // Helper function for markdown rendered marked
-// Renders links outside apify.com in readme with rel="noopener noreferrer nofollow" and target="_blank" attributes
+// If passed hostname, it renders links outside that hostname in readme with rel="noopener noreferrer" and target="_blank" attributes
+// And links outside apify.com in readme with rel="noopener noreferrer nofollow" and target="_blank" attributes
 export function markedSetNofollowLinks(href: string, title: string, text: string, hostname?: string) {
     let urlParsed: URL;
     try {


### PR DESCRIPTION
Needed to solve https://github.com/apify/apify-core/issues/18466.
Now the `rel="noopener noreferrer nofollow" target="_blank"` is added only if url is outside from `apify.com` domain.
This enable passing hostname to `markedSetNofollowLinks` function and setting `rel="noopener noreferrer" target="_blank"` for apify domain but different hostname.

Once this is merged, next step would be to pass hostname from `safeMarkdown` in console/frontend down to `markedSetNofollowLinks`