### PR TITLE
feat: get `betterSetInterval` ready for 2025

### DIFF
--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -342,3 +342,62 @@ describe('timeoutPromise()', () => {
         });
     });
 });
+
+describe('BetterSetInterval', () => {
+    it('works with normal function', async () => {
+        const fn = jest.fn();
+
+        const interval = utils.betterSetInterval(fn, 200);
+
+        // 3 x 200ms + some leeway
+        await utils.delayPromise(700);
+        utils.betterClearInterval(interval);
+
+        // 1st call is immediate, 3 more after 1, 2 and 3 intervals
+        expect(fn).toHaveBeenCalledTimes(4);
+
+        // No more calls after clearing the interval
+        await utils.delayPromise(500);
+        expect(fn).toHaveBeenCalledTimes(4);
+    });
+
+    it('works with async function', async () => {
+        const fn = jest.fn();
+
+        const interval = utils.betterSetInterval(async () => {
+            fn();
+            await utils.delayPromise(100);
+        }, 200);
+
+        // 3 x (200 + 100)ms + some leeway
+        await utils.delayPromise(1000);
+        utils.betterClearInterval(interval);
+
+        // 1st call is immediate, 3 more after 1, 2 and 3 intervals
+        expect(fn).toHaveBeenCalledTimes(4);
+
+        // No more calls after clearing the interval
+        await utils.delayPromise(500);
+        expect(fn).toHaveBeenCalledTimes(4);
+    });
+
+    it('works with function that accepts a callback (legacy)', async () => {
+        const fn = jest.fn();
+
+        const interval = utils.betterSetInterval((cb: () => void) => {
+            fn();
+            cb();
+        }, 200);
+
+        // 3 x 200ms + some leeway
+        await utils.delayPromise(700);
+        utils.betterClearInterval(interval);
+
+        // 1st call is immediate, 3 more after 1, 2 and 3 intervals
+        expect(fn).toHaveBeenCalledTimes(4);
+
+        // No more calls after clearing the interval
+        await utils.delayPromise(500);
+        expect(fn).toHaveBeenCalledTimes(4);
+    });
+});


### PR DESCRIPTION
Historically, functions scheduled with `betterSetInterval` needed to accept a callback and then call it when done, to schedule their next invocation. This was because Promises were not a thing in 2015 when this function was originally written. It's silly to have this requirement now, almost ten years later, when async/await and Promises are a normal feature.

This change adds support for scheduling any function, sync or async, accepting or not accepting a callback, and having it just work.

```js
betterSetInterval(async () => {
    await myAsyncOperation();
}, 1000);
```

For backwards compatibility reasons, a dummy callback is still passed to the invoked function as its first argument, otherwise the functions that don't expect this change would break.