### PR TITLE
feat: add support for SOCKS to PROXY_URL_REGEX

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -53,12 +53,11 @@ export const APIFY_PROXY_VALUE_REGEX = /^[\w._~]+$/;
 /**
  * Regular expression to validate proxy urls, matches
  * http://asd:qweqwe@proxy.apify.com:8000
- * http://asd:qweqwe@proxy.apify.com:8000/
  * http://123123:qweqwe:asdasd@proxy.com:55555
  * http://proxy.apify.com:5000
  * http://root@proxy.apify.com:5000
  */
-export const PROXY_URL_REGEX = /^https?:\/\/(([^:]+:)?[^@]*@)?[^.:@]+\.[^:]+:[\d]+?$/;
+export const PROXY_URL_REGEX = /^(socks(4|4a|5|5h)?|https?):\/\/(([^:]+:)?[^@]*@)?[^.:@]+\.[^:]+:[\d]+?$/;
 
 /**
  * AWS S3 docs say:

--- a/packages/input_schema/src/intl.ts
+++ b/packages/input_schema/src/intl.ts
@@ -20,7 +20,7 @@ const intlStrings = {
     'inputSchema.validation.proxyGroupsNotAvailable':
         'You currently do not have access to proxy groups: {groups}',
     'inputSchema.validation.customProxyInvalid':
-        'Proxy URL "{invalidUrl}" has invalid format, it must be http[s]://[username[:password]]@hostname:port.',
+        'Proxy URL "{invalidUrl}" has invalid format, it must be socks[4|4a|5|5h]|http[s]://[username[:password]]@hostname:port.',
     'inputSchema.validation.apifyProxyCountryInvalid':
         'Country code "{invalidCountry}" is invalid. Only ISO 3166-1 alpha-2 country codes are supported.',
     'inputSchema.validation.apifyProxyCountryWithoutApifyProxyForbidden':

--- a/test/regexs.test.ts
+++ b/test/regexs.test.ts
@@ -317,6 +317,30 @@ const tests = {
             'https://www.linkedin.com/company/companyname/extra/extra/',
         ],
     },
+    PROXY_URL_REGEX: {
+        valid: [
+            'http://asd:qweqwe@proxy.apify.com:8000',
+            'http://asd:qweqwe@proxy.apify.com:8000',
+            'http://123123:qweqwe:asdasd@proxy.com:55555',
+            'http://proxy.apify.com:5000',
+            'http://root@proxy.apify.com:5000',
+            'https://proxy.apify.com:5000',
+            'socks://proxy.apify.com:5000',
+            'socks4://proxy.apify.com:5000',
+            'socks4a://proxy.apify.com:5000',
+            'socks5://proxy.apify.com:5000',
+            'socks5h://proxy.apify.com:5000',
+        ],
+        invalid: [
+            'http://@proxy.apify.com:8000/',
+            'https://proxy.apify.com',
+            'httpss://proxy.apify.com:5000',
+            'htt://proxy.apify.com:5000',
+            'soks://proxy.apify.com:5000',
+            'socks3://proxy.apify.com:5000',
+            'socks6://proxy.apify.com:5000',
+        ],
+    },
 };
 
 describe('regexps', () => {


### PR DESCRIPTION
This PR adds support for SOCKS protocols into the `PROXY_URL_REGEX`. I also added unit tests for it while I was at it. 