### PR TITLE
feat: fileUrl as string editor type

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -88,7 +88,7 @@
                 "title": { "type": "string" },
                 "description": { "type": "string" },
                 "nullable": { "type": "boolean" },
-                "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden"] },
+                "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden", "fileUrl"] },
                 "isSecret": { "type": "boolean" }
             },
             "required": ["type", "title", "description", "editor"],
@@ -139,7 +139,7 @@
                         "nullable": { "type": "boolean" },
                         "minLength": { "type": "integer" },
                         "maxLength": { "type": "integer" },
-                        "editor": { "enum": ["javascript", "python", "textfield", "textarea", "hidden"] },
+                        "editor": { "enum": ["javascript", "python", "textfield", "textarea", "hidden", "fileUrl"] },
                         "isSecret": { "enum": [false] },
                         "sectionCaption": { "type": "string" },
                         "sectionDescription": { "type": "string" }

--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -88,7 +88,7 @@
                 "title": { "type": "string" },
                 "description": { "type": "string" },
                 "nullable": { "type": "boolean" },
-                "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden", "fileUrl"] },
+                "editor": { "enum": ["javascript", "python", "textfield", "textarea", "datepicker", "hidden", "fileupload"] },
                 "isSecret": { "type": "boolean" }
             },
             "required": ["type", "title", "description", "editor"],
@@ -139,7 +139,7 @@
                         "nullable": { "type": "boolean" },
                         "minLength": { "type": "integer" },
                         "maxLength": { "type": "integer" },
-                        "editor": { "enum": ["javascript", "python", "textfield", "textarea", "hidden", "fileUrl"] },
+                        "editor": { "enum": ["javascript", "python", "textfield", "textarea", "hidden", "fileupload"] },
                         "isSecret": { "enum": [false] },
                         "sectionCaption": { "type": "string" },
                         "sectionDescription": { "type": "string" }

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -11,7 +11,7 @@ type CommonFieldDefinition<T> = {
 
 export type StringFieldDefinition = CommonFieldDefinition<string> & {
     type: 'string'
-    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json' | 'fileUrl';
+    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json' | 'fileupload';
     pattern?: string;
     minLength?: number;
     maxLength?: number;

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -11,7 +11,7 @@ type CommonFieldDefinition<T> = {
 
 export type StringFieldDefinition = CommonFieldDefinition<string> & {
     type: 'string'
-    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json';
+    editor: 'textfield' | 'textarea' | 'javascript' | 'python' | 'select' | 'datepicker' | 'hidden' | 'json' | 'fileUrl';
     pattern?: string;
     minLength?: number;
     maxLength?: number;

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -33,6 +33,12 @@ describe('input_schema.json', () => {
                         enum: ['a', 'b', 'c'],
                         enumTitles: ['A', 'B', 'C'],
                     },
+                    myField4: {
+                        title: 'Field title',
+                        type: 'string',
+                        description: 'Some description ...',
+                        editor: 'fileUrl',
+                    },
                 },
             };
 
@@ -157,7 +163,7 @@ describe('input_schema.json', () => {
 
             expect(() => validateInputSchema(validator, schema)).toThrow(
                 'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values: '
-                + '"javascript", "python", "textfield", "textarea", "hidden")',
+                + '"javascript", "python", "textfield", "textarea", "hidden", "fileUrl")',
             );
         });
 

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -37,7 +37,7 @@ describe('input_schema.json', () => {
                         title: 'Field title',
                         type: 'string',
                         description: 'Some description ...',
-                        editor: 'fileUrl',
+                        editor: 'fileupload',
                     },
                 },
             };
@@ -163,7 +163,7 @@ describe('input_schema.json', () => {
 
             expect(() => validateInputSchema(validator, schema)).toThrow(
                 'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values: '
-                + '"javascript", "python", "textfield", "textarea", "hidden", "fileUrl")',
+                + '"javascript", "python", "textfield", "textarea", "hidden", "fileupload")',
             );
         });
 


### PR DESCRIPTION
We want to add file upload to the input schema, decided to go with url on the input.

Seems like a good idea to just use a special editor for this, instead of adding a new input type. The default fallback editor should work reasonably well everywhere.

### Related PRs:
 - https://github.com/apify/apify-docs/pull/1524