### PR TITLE
feat(schema): add support for resource permissions

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -308,6 +308,18 @@
                 "description": { "type": "string" },
                 "editor": { "enum": ["resourcePicker", "hidden"] },
                 "resourceType": { "enum": ["dataset", "keyValueStore", "requestQueue"] },
+                "resourcePermissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["READ", "WRITE"]
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "contains": {
+                        "const": "READ"
+                    }
+                },
                 "default": { "type": "string" },
                 "prefill": { "type": "string" },
                 "example": { "type": "string" },
@@ -315,7 +327,22 @@
                 "sectionCaption": { "type": "string" },
                 "sectionDescription": { "type": "string" }
             },
-            "required": ["type", "title", "description", "resourceType"]
+            "required": ["type", "title", "description", "resourceType"],
+            "allOf": [
+                {
+                    "if": {
+                        "required": ["resourcePermissions"]
+                    },
+                    "then": {
+                        "not": {
+                            "anyOf": [
+                                { "required": ["prefill"] },
+                                { "required": ["default"] }
+                            ]
+                        }
+                    }
+                }
+            ]
         },
         "resourceArrayProperty": {
             "title": "Resource array property",
@@ -326,6 +353,18 @@
                 "title": { "type": "string" },
                 "description": { "type": "string" },
                 "editor": { "enum": ["resourcePicker", "hidden"] },
+                "resourcePermissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["READ", "WRITE"]
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "contains": {
+                        "const": "READ"
+                    }
+                },
                 "default": { "type": "array" },
                 "prefill": { "type": "array" },
                 "example": { "type": "array" },
@@ -337,7 +376,22 @@
                 "sectionCaption": { "type": "string" },
                 "sectionDescription": { "type": "string" }
             },
-            "required": ["type", "title", "description", "resourceType"]
+            "required": ["type", "title", "description", "resourceType"],
+            "allOf": [
+                {
+                    "if": {
+                        "required": ["resourcePermissions"]
+                    },
+                    "then": {
+                        "not": {
+                            "anyOf": [
+                                { "required": ["prefill"] },
+                                { "required": ["default"] }
+                            ]
+                        }
+                    }
+                }
+            ]
         },
         "anyProperty": {
             "title": "Any property",

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -62,6 +62,7 @@ export type ArrayFieldDefinition = CommonFieldDefinition<unknown[]> & {
 export type CommonResourceFieldDefinition<T> = CommonFieldDefinition<T> & {
     editor?: 'resourcePicker' | 'hidden';
     resourceType: 'dataset' | 'keyValueStore' | 'requestQueue';
+    resourcePermissions?: ('READ' | 'WRITE')[];
 }
 
 export type ResourceFieldDefinition = CommonResourceFieldDefinition<string> & {

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -287,6 +287,25 @@ describe('input_schema.json', () => {
         });
 
         describe('special cases for resourceProperty', () => {
+            it('should accept valid resourceType', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            prefill: 'test',
+                            default: 'test',
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema)).not.toThrow();
+            });
+
             it('should not accept invalid resourceType', () => {
                 const schema = {
                     title: 'Test input schema',
@@ -324,6 +343,143 @@ describe('input_schema.json', () => {
                 };
                 expect(() => validateInputSchema(validator, schema)).toThrow(
                     'Input schema is not valid (Field schema.properties.myField.editor must be equal to one of the allowed values: "resourcePicker", "hidden")',
+                );
+            });
+
+            it('should accept valid resourcePermissions', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['READ'],
+                        },
+                    },
+                };
+                validateInputSchema(validator, schema);
+
+                const schema2 = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['READ', 'WRITE'],
+                        },
+                    },
+                };
+                validateInputSchema(validator, schema2);
+            });
+
+            it('should not accept invalid resourcePermissions values', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['INVALID'],
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myField.0 must be equal to one of the allowed values: "READ", "WRITE")',
+                );
+            });
+
+            it('should not accept empty resourcePermissions array', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: [],
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myField.resourcePermissions must NOT have fewer than 1 items)',
+                );
+            });
+
+            it('should not accept resourcePermissions with prefill', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['READ'],
+                            prefill: 'some-value',
+                        },
+                    },
+                };
+
+                expect(() => validateInputSchema(validator, schema)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myField. must NOT be valid)',
+                );
+            });
+
+            it('should not accept resourcePermissions with default', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['READ'],
+                            default: 'some-value',
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myField. must NOT be valid)',
+                );
+            });
+
+            it('should not accept resourcePermissions without READ', () => {
+                const schema = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'string',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['WRITE'],
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myField.resourcePermissions must contain at least 1 valid item(s))',
                 );
             });
         });

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -304,6 +304,23 @@ describe('input_schema.json', () => {
                     },
                 };
                 expect(() => validateInputSchema(validator, schema)).not.toThrow();
+
+                const schema2 = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myFieldArray: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'array',
+                            resourceType: 'keyValueStore',
+                            prefill: [],
+                            default: [],
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema2)).not.toThrow();
             });
 
             it('should not accept invalid resourceType', () => {
@@ -368,10 +385,10 @@ describe('input_schema.json', () => {
                     type: 'object',
                     schemaVersion: 1,
                     properties: {
-                        myField: {
+                        myFieldArray: {
                             title: 'Field title',
                             description: 'My test field',
-                            type: 'string',
+                            type: 'array',
                             resourceType: 'keyValueStore',
                             resourcePermissions: ['READ', 'WRITE'],
                         },
@@ -397,6 +414,24 @@ describe('input_schema.json', () => {
                 };
                 expect(() => validateInputSchema(validator, schema)).toThrow(
                     'Input schema is not valid (Field schema.properties.myField.0 must be equal to one of the allowed values: "READ", "WRITE")',
+                );
+
+                const schema2 = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myFieldArray: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'array',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['INVALID'],
+                        },
+                    },
+                };
+                expect(() => validateInputSchema(validator, schema2)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myFieldArray.0 must be equal to one of the allowed values: "READ", "WRITE")',
                 );
             });
 
@@ -438,6 +473,26 @@ describe('input_schema.json', () => {
                 };
 
                 expect(() => validateInputSchema(validator, schema)).toThrow(
+                    'Input schema is not valid (Field schema.properties.myField. must NOT be valid)',
+                );
+
+                const schema2 = {
+                    title: 'Test input schema',
+                    type: 'object',
+                    schemaVersion: 1,
+                    properties: {
+                        myField: {
+                            title: 'Field title',
+                            description: 'My test field',
+                            type: 'array',
+                            resourceType: 'keyValueStore',
+                            resourcePermissions: ['READ'],
+                            prefill: [],
+                        },
+                    },
+                };
+
+                expect(() => validateInputSchema(validator, schema2)).toThrow(
                     'Input schema is not valid (Field schema.properties.myField. must NOT be valid)',
                 );
             });


### PR DESCRIPTION
As part of the [Actor permissions project](https://www.notion.so/apify/Public-Actor-permissions-design-document-1d1f39950a228015a679f276104123cb), we want to allow Actors to request access to resources via schema.

- The Actor input schema already supports annotating string fields with a `resourceType` to specify that the field should reference an Apify platform resource (practically, a storage, such as a dataset).
- This PR extends the input schema so that the Actor can not only specify that a certain string is actually a storage ID, but also what kind of access to the storage the Actor will require (read, or also write). For that reason, the PR adds a new property `resourcePermissions`.
- We will then use this information both to communicate this Actor requirement to the user, and to correctly configure the access when running the Actor.

Example input schema configuration:

```json
{
    "title": "Dataset",
    "type": "string",
    "description": "Select a dataset that you want to process",
    "resourceType": "dataset",
    "resourcePermissions": ["READ", "WRITE"],
}
```

The `resourcePermissions` property follows the same permission format as we use elsewhere in Apify. The Actor developer will be able to specify:

- Nothing → No access at all (works only for full permission Actors).
- `["READ"]`  → The Actor will be able to read the storage.
- `["READ", "WRITE"]` → The Actor will be able to write the storage as well.

We don't support just `["WRITE"]`, which is enforced via schema validation. Later we might choose to introduce "append only" storages.

To address a potential security loophole, the validation also forbids the use of `default` and `prefill` if `resourcePermissions` is set. This is not a breaking change as existing schemas will work just fine until the developer decides to provide `resourcePermissions`.

For additional context refer to the [design doc](https://www.notion.so/apify/Public-Actor-permissions-design-document-1d1f39950a228015a679f276104123cb).