### PR TITLE
feat(input_schema): Enable secret objects

### DIFF
--- a/packages/input_schema/src/schema.json
+++ b/packages/input_schema/src/schema.json
@@ -237,25 +237,58 @@
         "objectProperty": {
             "title": "Object property",
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "type": { "enum": ["object"] },
                 "title": { "type": "string" },
                 "description": { "type": "string" },
-                "default": { "type": "object" },
-                "prefill": { "type": "object" },
-                "example": { "type": "object" },
-                "patternKey": { "type": "string" },
-                "patternValue": { "type": "string" },
-                "nullable": { "type": "boolean" },
-                "minProperties": { "type": "integer" },
-                "maxProperties": { "type": "integer" },
-
                 "editor": { "enum": ["json", "proxy", "hidden"] },
-                "sectionCaption": { "type": "string" },
-                "sectionDescription": { "type": "string" }
+                "isSecret": { "type": "boolean" }
             },
-            "required": ["type", "title", "description", "editor"]
+            "required": ["type", "title", "description", "editor"],
+            "if": {
+                "properties": {
+                    "isSecret": {
+                        "not": {
+                            "const": true
+                        }
+                    }
+                }
+            },
+            "then": {
+                "additionalProperties": false,
+                "properties": {
+                    "type": { "enum": ["object"] },
+                    "title": { "type": "string" },
+                    "description": { "type": "string" },
+                    "default": { "type": "object" },
+                    "prefill": { "type": "object" },
+                    "example": { "type": "object" },
+                    "patternKey": { "type": "string" },
+                    "patternValue": { "type": "string" },
+                    "nullable": { "type": "boolean" },
+                    "minProperties": { "type": "integer" },
+                    "maxProperties": { "type": "integer" },
+                    "editor": { "enum": ["json", "proxy", "hidden"] },
+                    "sectionCaption": { "type": "string" },
+                    "sectionDescription": { "type": "string" },
+                    "isSecret": { "enum": [false] }
+                }
+            },
+            "else": {
+                "additionalProperties": false,
+                "properties": {
+                    "type": { "enum": ["object"] },
+                    "title": { "type": "string" },
+                    "description": { "type": "string" },
+                    "example": { "type": "object" },
+                    "nullable": { "type": "boolean" },
+                    "editor": { "enum": ["json", "hidden"] },
+                    "sectionCaption": { "type": "string" },
+                    "sectionDescription": { "type": "string" },
+                    "isSecret": { "enum": [true] }
+                }
+            }
         },
         "integerProperty": {
             "title": "Integer property",

--- a/packages/input_secrets/src/input_secrets.ts
+++ b/packages/input_secrets/src/input_secrets.ts
@@ -23,13 +23,29 @@ export function getInputSchemaSecretFieldKeys(inputSchema: any): string[] {
 
 /**
  * Encrypts input secret value
+ * Depending on the type of value, it returns either a string (for strings) or an object (for objects) with the `secret` key.
  */
-export function encryptInputSecretValue({ value, publicKey }: { value: string, publicKey: KeyObject }): string {
-    ow(value, ow.string);
+export function encryptInputSecretValue<T extends string | object>({ value, publicKey }: { value: T, publicKey: KeyObject }):
+    T extends string ? string : { secret: string } {
+    ow(value, ow.any(ow.string, ow.object));
     ow(publicKey, ow.object.instanceOf(KeyObject));
 
-    const { encryptedValue, encryptedPassword } = publicEncrypt({ value, publicKey });
-    return `${ENCRYPTED_INPUT_VALUE_PREFIX}:${encryptedPassword}:${encryptedValue}`;
+    type ResultType = T extends string ? string : { secret: string };
+
+    if (typeof value === 'string') {
+        const { encryptedValue, encryptedPassword } = publicEncrypt({ value, publicKey });
+        return `${ENCRYPTED_INPUT_VALUE_PREFIX}:${encryptedPassword}:${encryptedValue}` as ResultType;
+    }
+
+    let valueStr: string;
+    try {
+        valueStr = JSON.stringify(value);
+    } catch (err) {
+        throw new Error(`The input value could not be stringified for encryption: ${err}`);
+    }
+    // For objects, we return an object with the encrypted JSON string under the 'secret' key.
+    const encryptedJSONString = encryptInputSecretValue({ value: valueStr, publicKey });
+    return { secret: encryptedJSONString } as ResultType;
 }
 
 /**
@@ -50,8 +66,17 @@ export function encryptInputSecrets<T extends Record<string, any>>(
         const value = input[key];
         // NOTE: Skips already encrypted values. It can happens in case client already encrypted values, before
         // sending them using API. Or input was takes from task, run console or scheduler, where input is stored encrypted.
-        if (value && ow.isValid(value, ow.string) && !ENCRYPTED_INPUT_VALUE_REGEXP.test(value)) {
-            encryptedInput[key] = encryptInputSecretValue({ value: input[key], publicKey });
+        const isUnencryptedString = ow.isValid(value, ow.string) && !ENCRYPTED_INPUT_VALUE_REGEXP.test(value);
+        const isUnencryptedObject = ow.isValid(value, ow.object)
+            && (typeof (value as any).secret !== 'string' || !ENCRYPTED_INPUT_VALUE_REGEXP.test((value as any).secret));
+
+        if (isUnencryptedString || isUnencryptedObject) {
+            try {
+                encryptedInput[key] = encryptInputSecretValue({ value: input[key], publicKey });
+            } catch (err) {
+                throw new Error(`The input field "${key}" could not be encrypted. Try updating the field's value in the input editor. `
+                    + `Encryption error: ${err}`);
+            }
         }
     }
 
@@ -72,7 +97,11 @@ export function decryptInputSecrets<T>(
 
     const decryptedInput = {} as Record<string, any>;
     for (const [key, value] of Object.entries(input)) {
-        if (ow.isValid(value, ow.string) && ENCRYPTED_INPUT_VALUE_REGEXP.test(value)) {
+        const isEncryptedString = typeof value === 'string' && ENCRYPTED_INPUT_VALUE_REGEXP.test(value);
+        const isEncryptedObject = typeof value === 'object' && typeof (value as any).secret === 'string'
+            && ENCRYPTED_INPUT_VALUE_REGEXP.test((value as any).secret);
+
+        if (isEncryptedString) {
             const match = value.match(ENCRYPTED_INPUT_VALUE_REGEXP);
             if (!match) continue;
             const [, encryptedPassword, encryptedValue] = match;
@@ -81,6 +110,15 @@ export function decryptInputSecrets<T>(
             } catch (err) {
                 throw new Error(`The input field "${key}" could not be decrypted. Try updating the field's value in the input editor. `
                 + `Decryption error: ${err}`);
+            }
+        } else if (isEncryptedObject) {
+            // For objects, we are passing the encrypted object with `secret` key as an input to decryption.
+            // So we extract the encrypted JSON string and can construct the decrypted object.
+            const decryptedJSONString = decryptInputSecrets({ input: { [key]: (value as any).secret }, privateKey })[key];
+            try {
+                decryptedInput[key] = JSON.parse(decryptedJSONString);
+            } catch (err) {
+                throw new Error(`The input field "${key}" could not be parsed as JSON after decryption: ${err}`);
             }
         }
     }


### PR DESCRIPTION
This is proposal to enable `isSecret` for objects in input. Currently this is available only for `string` fields with editors either `textfield` or `textarea`.
Based on the issue [requirements](https://github.com/apify/apify-core/issues/21369)
> An ideal solution would be if we could encrypt objects

In addition to change of Input Schema's JSON schema change it's required to change also the encryption logic.
If input is `string`, there is no change and it's stored in input in form as `TODO`.
In case of `object` input, we need to keep the value as `object` because of validation of input. This propose to store encrypted objects as object with structure:
```
{
  "secret": "encrypted-json-string-of-original-object"
}
```