### PR TITLE
feat(json_schemas): Add $id property to JSON schemas

### DIFF
--- a/packages/input_schema/src/input_schema.ts
+++ b/packages/input_schema/src/input_schema.ts
@@ -114,8 +114,11 @@ const validateAgainstSchemaOrThrow = (validator: Ajv, obj: Record<string, unknow
  * We override schema.properties.properties not to validate field definitions.
  */
 function validateBasicStructure(validator: Ajv, obj: Record<string, unknown>): asserts obj is InputSchemaBaseChecked {
+    // We need to remove $id from the schema, because AJV cache the schema by id and if we provide
+    // different schema instance with the same id, it will throw an error.
+    const { $id, ...schemaWithoutId } = schema;
     const schemaWithoutProperties = {
-        ...schema,
+        ...schemaWithoutId,
         properties: { ...schema.properties, properties: { type: 'object' } as any },
     };
     validateAgainstSchemaOrThrow(validator, obj, schemaWithoutProperties, 'schema');

--- a/packages/json_schemas/schemas/actor.schema.json
+++ b/packages/json_schemas/schemas/actor.schema.json
@@ -1,8 +1,11 @@
 {
-  "$id": "actor.json",
+  "$id": "https://apify.com/schemas/v1/actor.json",
   "title": "JSON schema of Apify Actor actor.json file",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "actorSpecification": {
       "type": "integer",
       "minimum": 1,
@@ -77,7 +80,7 @@
           "type": "string"
         },
         {
-          "$ref": "output.json"
+          "$ref": "https://apify.com/schemas/v1/output.json"
         }
       ]
     },
@@ -87,7 +90,7 @@
           "type": "string"
         },
         {
-          "$ref": "output.json"
+          "$ref": "https://apify.com/schemas/v1/output.json"
         }
       ]
     },
@@ -100,7 +103,7 @@
               "type": "string"
             },
             {
-              "$ref": "key_value_store.json"
+              "$ref": "https://apify.com/schemas/v1/key-value-store.json"
             }
           ]
         },
@@ -110,7 +113,7 @@
               "type": "string"
             },
             {
-              "$ref": "dataset.json"
+              "$ref": "https://apify.com/schemas/v1/dataset.json"
             }
           ]
         },

--- a/packages/json_schemas/schemas/dataset.schema.json
+++ b/packages/json_schemas/schemas/dataset.schema.json
@@ -1,8 +1,11 @@
 {
-    "$id": "dataset.json",
+    "$id": "https://apify.com/schemas/v1/dataset.json",
     "title": "JSON schema of Apify Actor dataset schema",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "actorSpecification": {
             "type": "integer",
             "minimum": 1,

--- a/packages/json_schemas/schemas/input.schema.json
+++ b/packages/json_schemas/schemas/input.schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "https://apify.com/schemas/v1/input.json",
     "title": "JSON schema of Apify Actor input",
     "type": "object",
     "properties": {

--- a/packages/json_schemas/schemas/key_value_store.schema.json
+++ b/packages/json_schemas/schemas/key_value_store.schema.json
@@ -1,8 +1,11 @@
 {
-    "$id": "key_value_store.json",
+    "$id": "https://apify.com/schemas/v1/key-value-store.json",
     "title": "JSON schema of Apify Actor key-value store schema",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "actorKeyValueStoreSchemaVersion": {
             "type": "integer",
             "minimum": 1,

--- a/packages/json_schemas/schemas/output.schema.json
+++ b/packages/json_schemas/schemas/output.schema.json
@@ -1,8 +1,11 @@
 {
-    "$id": "output.json",
+    "$id": "https://apify.com/schemas/v1/output.json",
     "title": "JSON schema of Apify Actor output schema",
     "type": "object",
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "actorOutputSchemaVersion": {
             "type": "integer",
             "minimum": 1,

--- a/packages/json_schemas/src/actor.schema.ts
+++ b/packages/json_schemas/src/actor.schema.ts
@@ -4,10 +4,13 @@ import { ACTOR_LIMITS } from '@apify/consts';
 // The schemas/actor.schema.json file is generated from this file during the build step.
 
 export const actorSchema = {
-    $id: 'actor.json',
+    $id: 'https://apify.com/schemas/v1/actor.json',
     title: 'JSON schema of Apify Actor actor.json file',
     type: 'object',
     properties: {
+        $schema: {
+            type: 'string',
+        },
         actorSpecification: {
             type: 'integer',
             minimum: 1,
@@ -82,7 +85,7 @@ export const actorSchema = {
                     type: 'string',
                 },
                 {
-                    $ref: 'output.json',
+                    $ref: 'https://apify.com/schemas/v1/output.json',
                 },
             ],
         },
@@ -92,7 +95,7 @@ export const actorSchema = {
                     type: 'string',
                 },
                 {
-                    $ref: 'output.json',
+                    $ref: 'https://apify.com/schemas/v1/output.json',
                 },
             ],
         },
@@ -105,7 +108,7 @@ export const actorSchema = {
                             type: 'string',
                         },
                         {
-                            $ref: 'key_value_store.json',
+                            $ref: 'https://apify.com/schemas/v1/key-value-store.json',
                         },
                     ],
                 },
@@ -115,7 +118,7 @@ export const actorSchema = {
                             type: 'string',
                         },
                         {
-                            $ref: 'dataset.json',
+                            $ref: 'https://apify.com/schemas/v1/dataset.json',
                         },
                     ],
                 },


### PR DESCRIPTION
We have JSON schemas publicly available at `https://apify.com/schemas`:
- [`https://apify.com/schemas/v1/actor.json`](https://apify.com/schemas/v1/actor.json)
- [`https://apify.com/schemas/v1/input.json`](https://apify.com/schemas/v1/input.json)
- [`https://apify.com/schemas/v1/dataset.json`](https://apify.com/schemas/v1/dataset.json)
- [`https://apify.com/schemas/v1/key-value-store.json`](https://apify.com/schemas/v1/key-value-store.json)
- [`https://apify.com/schemas/v1/output.json`](https://apify.com/schemas/v1/output.json)

This sets the `$id` property to the respective URL.

Also add optional `$schema` property to all schemas so the actual schema can link the validation schema (our JSON schema) to provide validation lints in IDE.