### PR TITLE
feat: add fileupload editor for string arrays

### DIFF
--- a/packages/json_schemas/schemas/input.schema.json
+++ b/packages/json_schemas/schemas/input.schema.json
@@ -179,7 +179,7 @@
             "type": "object",
             "properties": {
                 "type": { "enum": ["array"] },
-                "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "select", "schemaBased", "hidden"] },
+                "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "fileupload", "select", "schemaBased", "hidden"] },
                 "isSecret": { "type": "boolean" }
             },
             "required": ["type", "title", "description", "editor"],
@@ -223,6 +223,13 @@
                                 "properties": {
                                     "editor": { "enum": ["keyValue"] },
                                     "items": { "$ref": "#/definitions/arrayItemsKeyValue" }
+                                }
+                            },
+                            {
+                                "required": ["editor"],
+                                "properties": {
+                                    "editor": { "enum": ["fileupload"] },
+                                    "items": { "$ref": "#/definitions/arrayItemsFileupload" }
                                 }
                             },
                             {
@@ -679,7 +686,7 @@
             "type": "object",
             "properties": {
                 "type": { "enum": ["array"] },
-                "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "select", "hidden"] },
+                "editor": { "enum": ["json", "requestListSources", "pseudoUrls", "globs", "keyValue", "stringList", "fileupload", "select", "hidden"] },
                 "title": { "type": "string" },
                 "description": { "type": "string" },
                 "nullable": { "type": "boolean" },
@@ -706,6 +713,13 @@
                     "properties": {
                         "editor": { "enum": ["keyValue"] },
                         "items": { "$ref": "#/definitions/arrayItemsKeyValue" }
+                    }
+                },
+                {
+                    "required": ["editor"],
+                    "properties": {
+                        "editor": { "enum": ["fileupload"] },
+                        "items": { "$ref": "#/definitions/arrayItemsFileupload" }
                     }
                 },
                 {
@@ -997,6 +1011,18 @@
         },
         "arrayItemsStringList": {
             "title": "Utils: Array items stringList definition",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": { "enum": ["string"] },
+                "pattern": { "type": "string" },
+                "minLength": { "type": "integer" },
+                "maxLength": { "type": "integer" }
+            },
+            "required": ["type"]
+        },
+        "arrayItemsFileupload": {
+            "title": "Utils: Array items fileupload definition",
             "type": "object",
             "additionalProperties": false,
             "properties": {

--- a/test/input_schema.test.ts
+++ b/test/input_schema.test.ts
@@ -39,6 +39,12 @@ describe('input_schema.json', () => {
                         description: 'Some description ...',
                         editor: 'fileupload',
                     },
+                    myfield5: {
+                        title: 'Array fileupload title',
+                        type: 'array',
+                        description: 'Some description...',
+                        editor: 'fileupload',
+                    },
                 },
             };
 


### PR DESCRIPTION
This PR allows the use of the `fileupload` input for an array of strings.

Instead of re-using the `arrayItemsStringlist` reference, I've added `arrayItemsFileupload` with the same shape.

It will work the same way as it currently works for a single string.

Related PR in console: https://github.com/apify/apify-core/pull/23289

The order of PRs does not matter: The UI will fallback to code input, and the input just won't do anything until it encounters the editor in schema.