### PR TITLE
feat(json_schemas): Do not allow colon in field keys in dataset fields schema

### DIFF
--- a/packages/json_schemas/schemas/dataset.schema.json
+++ b/packages/json_schemas/schemas/dataset.schema.json
@@ -18,7 +18,20 @@
             "type": "string"
         },
         "fields": {
-            "$ref": "http://json-schema.org/draft-07/schema#"
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-07/schema#" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "properties": {
+                            "type": "object",
+                            "propertyNames": {
+                                "pattern": "^[^:]+$"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "views": {
             "type": "object",

--- a/test/dataset_schema.test.ts
+++ b/test/dataset_schema.test.ts
@@ -229,5 +229,29 @@ describe('dataset.json', () => {
                 }),
             );
         });
+
+        it('should not allow colon (:) in field names', () => {
+            const schema = {
+                actorSpecification: 1,
+                title: 'My Dataset',
+                description: 'This is my dataset',
+                fields: {
+                    properties: {
+                        'my:field': {
+                            type: 'string',
+                        },
+                    },
+                },
+            };
+
+            const isValid = validator(schema);
+            expect(isValid).toBe(false);
+            expect(validator.errors).toContainEqual(
+                expect.objectContaining({
+                    instancePath: '/fields/properties',
+                    message: 'must match pattern "^[^:]+$"',
+                }),
+            );
+        });
     });
 });


### PR DESCRIPTION
Do not allow using colon in field keys in dataset fields schema.

There's issue when dataset field in the dataset schemas has colon in the key, because when we're collecting dataset statistics (in `MongoUpdateThrottled`) we put commands to redis in form `{operation}:{mongoDocumentId}:{propertyName}:{value}`, like `inc:{mongoDocumentId}:property:20`. Then when we're actually updating the mongodb document we get these values from redis and split it by `:`. 

So if the `property` has colon inside it breaks.

Reported here: https://apify.slack.com/archives/C0L33UM7Z/p1759569404545289

