### PR TITLE
chore: deprecate `input` and `output` fields in favor of `inputSchema` and `outputSchema`

### DIFF
--- a/packages/json_schemas/output/actor.ide.json
+++ b/packages/json_schemas/output/actor.ide.json
@@ -122,9 +122,10 @@
                     "$ref": "#/definitions/input-ide-json-2212166aa408babb6120b85f1282521a"
                 }
             ],
-            "description": "Path or direct definition of the Actor's input schema.",
-            "x-intellij-html-description": "<p>Path or direct definition of the Actor's input schema.</p>",
-            "markdownDescription": "Path or direct definition of the Actor's input schema."
+            "description": "Deprecated: Please use inputSchema instead.",
+            "x-intellij-html-description": "<p><strong>Deprecated: Please use <code>inputSchema</code> instead.</strong></p>",
+            "markdownDescription": "**Deprecated: Please use `inputSchema` instead.**",
+            "deprecated": true
         },
         "inputSchema": {
             "oneOf": [
@@ -148,9 +149,10 @@
                     "$ref": "#/definitions/output-ide-json-413958f869eb5571ee0afb984606c27b"
                 }
             ],
-            "description": "Path or direct definition of the Actor's output schema.",
-            "x-intellij-html-description": "<p>Path or direct definition of the Actor's output schema.</p>",
-            "markdownDescription": "Path or direct definition of the Actor's output schema."
+            "description": "Deprecated: Please use outputSchema instead.",
+            "x-intellij-html-description": "<p><strong>Deprecated: Please use <code>outputSchema</code> instead.</strong></p>",
+            "markdownDescription": "**Deprecated: Please use `outputSchema` instead.**",
+            "deprecated": true
         },
         "outputSchema": {
             "oneOf": [
@@ -263,6 +265,38 @@
         "name"
     ],
     "additionalProperties": false,
+    "allOf": [
+        {
+            "if": {
+                "required": [
+                    "inputSchema"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "input": {
+                        "not": {},
+                        "description": "Cannot be used together with 'inputSchema'."
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "required": [
+                    "outputSchema"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "output": {
+                        "not": {},
+                        "description": "Cannot be used together with 'outputSchema'."
+                    }
+                }
+            }
+        }
+    ],
     "definitions": {
         "input-ide-json-2212166aa408babb6120b85f1282521a": {
             "title": "JSON schema of Apify Actor input",

--- a/packages/json_schemas/output/actor.json
+++ b/packages/json_schemas/output/actor.json
@@ -90,9 +90,9 @@
                     "type": "object"
                 }
             ],
-            "description": "Path or direct definition of the Actor's input schema.",
-            "x-intellij-html-description": "<p>Path or direct definition of the Actor's input schema.</p>",
-            "markdownDescription": "Path or direct definition of the Actor's input schema."
+            "description": "Deprecated: Please use inputSchema instead.",
+            "x-intellij-html-description": "<p><strong>Deprecated: Please use <code>inputSchema</code> instead.</strong></p>",
+            "markdownDescription": "**Deprecated: Please use `inputSchema` instead.**"
         },
         "inputSchema": {
             "oneOf": [
@@ -116,9 +116,9 @@
                     "$ref": "https://apify.com/schemas/v1/output.json"
                 }
             ],
-            "description": "Path or direct definition of the Actor's output schema.",
-            "x-intellij-html-description": "<p>Path or direct definition of the Actor's output schema.</p>",
-            "markdownDescription": "Path or direct definition of the Actor's output schema."
+            "description": "Deprecated: Please use outputSchema instead.",
+            "x-intellij-html-description": "<p><strong>Deprecated: Please use <code>outputSchema</code> instead.</strong></p>",
+            "markdownDescription": "**Deprecated: Please use `outputSchema` instead.**"
         },
         "outputSchema": {
             "oneOf": [

--- a/packages/json_schemas/rules/add-description/actor.description-rules.xml
+++ b/packages/json_schemas/rules/add-description/actor.description-rules.xml
@@ -12,13 +12,13 @@
         An integer between `128` and `32768` specifying the maximum memory in megabytes allowed.
     </AddDescription>
     <AddDescription json-path="/properties/input" format="markdown">
-        Path or direct definition of the Actor's input schema.
+        **Deprecated: Please use `inputSchema` instead.**
     </AddDescription>
     <AddDescription json-path="/properties/inputSchema" format="markdown">
         Path or direct definition of the Actor's input schema.
     </AddDescription>
     <AddDescription json-path="/properties/output" format="markdown">
-        Path or direct definition of the Actor's output schema.
+        **Deprecated: Please use `outputSchema` instead.**
     </AddDescription>
     <AddDescription json-path="/properties/outputSchema" format="markdown">
         Path or direct definition of the Actor's output schema.

--- a/packages/json_schemas/rules/modification-rules-schema.xsd
+++ b/packages/json_schemas/rules/modification-rules-schema.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="https://apify.com/json/modifications"
+           xmlns="https://apify.com/json/modifications"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <!-- Root element -->
+    <xs:element name="Enchantments">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:choice>
+                    <xs:element ref="AddDescription"/>
+                    <xs:element ref="ReplaceValue"/>
+                    <xs:element ref="RemoveValue"/>
+                </xs:choice>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- AddDescription -->
+    <xs:simpleType name="AddDescriptionFormat">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="markdown"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="AddDescription">
+        <xs:complexType mixed="true">
+            <xs:attribute name="json-path" type="xs:string" use="required"/>
+            <xs:attribute name="format" type="AddDescriptionFormat" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- ReplaceValue -->
+    <xs:simpleType name="ReplaceValueType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="json"/>
+            <xs:enumeration value="js"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="ReplaceValue">
+        <xs:complexType mixed="true">
+            <xs:attribute name="json-path" type="xs:string" use="required"/>
+            <xs:attribute name="type" type="ReplaceValueType" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- RemoveValue -->
+    <xs:element name="RemoveValue">
+        <xs:complexType>
+            <xs:attribute name="json-path" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/packages/json_schemas/rules/modifications/actor.modification-rules.xml
+++ b/packages/json_schemas/rules/modifications/actor.modification-rules.xml
@@ -8,9 +8,19 @@
     <ReplaceValue json-path="**/$ref" type="js">
         value.replace(/^https:\/\/apify\.com\/schemas\/v1\/(.+)\.json/, '$1.ide.json')
     </ReplaceValue>
+    <!-- Replace $ref value due to the relative path to input.ide.json -->
     <ReplaceValue json-path="/properties/inputSchema/oneOf" type="json">
         [{ "type": "string" }, { "$ref": "input.ide.json" }]
     </ReplaceValue>
+    <!-- Sets input attribute deprecated -->
+    <ReplaceValue json-path="/properties/input" type="js">
+        ({ ...value, deprecated: true })
+    </ReplaceValue>
+    <!-- Sets output attribute deprecated -->
+    <ReplaceValue json-path="/properties/output" type="js">
+        ({ ...value, deprecated: true })
+    </ReplaceValue>
+    <!-- Replace $ref value due to the relative path to input.ide.json -->
     <ReplaceValue json-path="/properties/input/oneOf" type="json">
         [{ "type": "string" }, { "$ref": "input.ide.json" }]
     </ReplaceValue>
@@ -24,7 +34,7 @@
     <ReplaceValue json-path="/properties/defaultMemoryMbytes" type="js">
         ({ ...value, oneOf: value.oneOf.map(v => v.type === "integer" ? { ...v, enum: [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] } : v) })
     </ReplaceValue>
-    <!-- In the original schema there is no support for meta attribute which is part of default Actor templates -->
+    <!-- In the original schema there is no support for `meta` attribute which is part of default Actor templates -->
     <ReplaceValue json-path="/properties" type="js">
         ({
             ...value,
@@ -34,8 +44,45 @@
             }
         })
     </ReplaceValue>
-    <!-- In the original schema these attributes have additionalProperties true, which is not great for code auto-complete -->
+    <!--
+    The original actor.json schema had `additionalProperties: true`, which allowed developers to define
+    whatever they wanted into root level attributes without any validation, we considered it as a bad DX, therefore
+    we are setting `additionalProperties` to false for IDEs.
+     -->
     <ReplaceValue json-path="/" type="js">
-        ({ ...value, additionalProperties: false })
+        ({
+            ...value,
+            // The original actor.json schema had `additionalProperties: true`, which allowed developers to define
+            // whatever they wanted for the root attributes without any validation, we considered it as a bad DX,
+            // therefore, we are setting `additionalProperties` to false for IDEs.
+            "additionalProperties": false,
+            // Following rules disallow to define input+inputSchema and output+outputSchema at the same time.
+            "allOf": [
+                {
+                    "if": { "required": ["inputSchema"] },
+                        "then": {
+                            "properties": {
+                                "input": {
+                                "not": {},
+                                // This description doesn't show anywhere, but if not present the validation doesn't work in Webstorm.
+                                "description": "Cannot be used together with 'inputSchema'."
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": { "required": ["outputSchema"] },
+                    "then": {
+                        "properties": {
+                            "output": {
+                                "not": {},
+                                // This description doesn't show anywhere, but if not present the validation doesn't work in Webstorm.
+                                "description": "Cannot be used together with 'outputSchema'."
+                            }
+                        }
+                    }
+                }
+            ],
+        })
     </ReplaceValue>
 </Enchantments>


### PR DESCRIPTION
Based on [discussion in Slack](https://apify.slack.com/archives/CD0SF6KD4/p1774997458909059) We want to mark `input` and `output` attributes as deprecated. And require mutually exclusive definitions for input/inputSchema and output/outputSchema.

Additionally I also noticed there was `modification-rules-schema.xsd` missing when the logic for describing and bundling json schemas was migrated from previous repository.