### PR TITLE
feat: add defaultMemoryMbytes to schema

### DIFF
--- a/packages/json_schemas/output/actor.ide.json
+++ b/packages/json_schemas/output/actor.ide.json
@@ -87,6 +87,19 @@
                 32768
             ]
         },
+        "defaultMemoryMbytes": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ],
+            "description": "Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a dynamic memory expression (https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory).",
+            "x-intellij-html-description": "<p>Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a <a href=\"https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory\">dynamic memory expression</a>.</p>",
+            "markdownDescription": "Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a [dynamic memory expression](https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory)."
+        },
         "input": {
             "oneOf": [
                 {

--- a/packages/json_schemas/output/actor.json
+++ b/packages/json_schemas/output/actor.json
@@ -66,6 +66,19 @@
             "x-intellij-html-description": "<p>An integer between <code>128</code> and <code>32768</code> specifying the maximum memory in megabytes allowed.</p>",
             "markdownDescription": "An integer between `128` and `32768` specifying the maximum memory in megabytes allowed."
         },
+        "defaultMemoryMbytes": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ],
+            "description": "Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a dynamic memory expression (https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory).",
+            "x-intellij-html-description": "<p>Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a <a href=\"https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory\">dynamic memory expression</a>.</p>",
+            "markdownDescription": "Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a [dynamic memory expression](https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory)."
+        },
         "input": {
             "oneOf": [
                 {

--- a/packages/json_schemas/rules/add-description/actor.description-rules.xml
+++ b/packages/json_schemas/rules/add-description/actor.description-rules.xml
@@ -2,6 +2,9 @@
 <Enchantments xmlns="https://apify.com/json/modifications"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://apify.com/json/modifications ../modification-rules-schema.xsd">
+    <AddDescription json-path="/properties/defaultMemoryMbytes" format="markdown">
+        Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a [dynamic memory expression](https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory).
+    </AddDescription>
     <AddDescription json-path="/properties/minMemoryMbytes" format="markdown">
         An integer between `128` and `32768` specifying the minimum memory in megabytes required.
     </AddDescription>

--- a/packages/json_schemas/schemas/actor.schema.json
+++ b/packages/json_schemas/schemas/actor.schema.json
@@ -60,6 +60,16 @@
       "minimum": 128,
       "maximum": 32768
     },
+    "defaultMemoryMbytes": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
     "input": {
       "oneOf": [
         {

--- a/packages/json_schemas/src/actor.schema.ts
+++ b/packages/json_schemas/src/actor.schema.ts
@@ -65,6 +65,12 @@ export const actorSchema = {
             minimum: ACTOR_LIMITS.MIN_RUN_MEMORY_MBYTES,
             maximum: ACTOR_LIMITS.MAX_RUN_MEMORY_MBYTES,
         },
+        defaultMemoryMbytes: {
+            oneOf: [
+                { type: 'string' },
+                { type: 'integer' },
+            ],
+        },
         input: {
             oneOf: [
                 {


### PR DESCRIPTION
Add `defaultMemoryMbytes` to schema