### PR TITLE
refactor: defaultMemoryMbytes use power of 2 enum

### DIFF
--- a/packages/json_schemas/output/actor.ide.json
+++ b/packages/json_schemas/output/actor.ide.json
@@ -93,7 +93,20 @@
                     "type": "string"
                 },
                 {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 128,
+                    "maximum": 32768,
+                    "enum": [
+                        128,
+                        256,
+                        512,
+                        1024,
+                        2048,
+                        4096,
+                        8192,
+                        16384,
+                        32768
+                    ]
                 }
             ],
             "description": "Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a dynamic memory expression (https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory).",

--- a/packages/json_schemas/output/actor.json
+++ b/packages/json_schemas/output/actor.json
@@ -72,7 +72,9 @@
                     "type": "string"
                 },
                 {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 128,
+                    "maximum": 32768
                 }
             ],
             "description": "Specifies the default amount of memory in megabytes to be used when the Actor is started. Can be an integer or a dynamic memory expression (https://docs.apify.com/platform/actors/development/actor-definition/dynamic-actor-memory).",

--- a/packages/json_schemas/rules/modifications/actor.modification-rules.xml
+++ b/packages/json_schemas/rules/modifications/actor.modification-rules.xml
@@ -21,6 +21,9 @@
     <ReplaceValue json-path="/properties/maxMemoryMbytes" type="js">
         ({ ...value, type: "integer", enum: [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] })
     </ReplaceValue>
+    <ReplaceValue json-path="/properties/defaultMemoryMbytes" type="js">
+        ({ ...value, oneOf: value.oneOf.map(v => v.type === "integer" ? { ...v, enum: [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] } : v) })
+    </ReplaceValue>
     <!-- In the original schema there is no support for meta attribute which is part of default Actor templates -->
     <ReplaceValue json-path="/properties" type="js">
         ({

--- a/packages/json_schemas/schemas/actor.schema.json
+++ b/packages/json_schemas/schemas/actor.schema.json
@@ -66,7 +66,9 @@
           "type": "string"
         },
         {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 128,
+          "maximum": 32768
         }
       ]
     },

--- a/packages/json_schemas/src/actor.schema.ts
+++ b/packages/json_schemas/src/actor.schema.ts
@@ -68,7 +68,7 @@ export const actorSchema = {
         defaultMemoryMbytes: {
             oneOf: [
                 { type: 'string' },
-                { type: 'integer' },
+                { type: 'integer', minimum: ACTOR_LIMITS.MIN_RUN_MEMORY_MBYTES, maximum: ACTOR_LIMITS.MAX_RUN_MEMORY_MBYTES },
             ],
         },
         input: {


### PR DESCRIPTION
This PR adds an enum validation to `defaultMemoryMbytes` and also adds minimum/maximum limits.

More context: https://github.com/apify/apify-shared-js/pull/609#pullrequestreview-4098977506