### PR TITLE
feat: Add more usernames to `FORBIDDEN_USERNAMES_REGEXPS`

### DIFF
--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -231,7 +231,9 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     'industries', 'web-scraping', 'custom-solutions', 'solution-provider', 'alternatives', 'platform',
     'freelancers', 'freelancer', 'partner', 'preview', 'templates', 'data-for-generative-ai',
     'discord', 'praguecrawl', 'prague-crawl', 'bob', 'ai-agents', 'reel', 'video-reel',
-    'mcp', 'mcpc', 'model-context-protocol', 'modelcontextprotocol', 'apify.com', 'design-kit', 'press-kit',
+    'mcp', 'mcpc', 'model-context-protocol', 'modelcontextprotocol',
+    // 'apify.com' intentionally unescaped so "." matches any character, also blocking variants like "apify_com" or "apifyxcom"
+    'apify.com', 'design-kit', 'press-kit',
     'scrapers', 'professional-services', 'challenge', 'challange', '1m-challenge', '1m-usd-challenge',
 
     // Apify platform resources

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -261,7 +261,7 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     'accessibility', 'imprint', 'impressum', 'trust', 'trust-center', 'security-center',
 
     // Brand protection / impersonation prevention
-    'brand', 'verified', 'apify-support', 'apify-team', 'support-team', 'abuse',
+    'brand', 'branding', 'verified', 'apify-support', 'apify-team', 'support-team', 'abuse',
 
     // Incidents / updates
     'outage', 'incident', 'incidents', 'what-is-new',

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -231,7 +231,7 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     'industries', 'web-scraping', 'custom-solutions', 'solution-provider', 'alternatives', 'platform',
     'freelancers', 'freelancer', 'partner', 'preview', 'templates', 'data-for-generative-ai',
     'discord', 'praguecrawl', 'prague-crawl', 'bob', 'ai-agents', 'reel', 'video-reel',
-    'mcp', 'model-context-protocol', 'modelcontextprotocol', 'apify.com', 'design-kit', 'press-kit',
+    'mcp', 'mcpc', 'model-context-protocol', 'modelcontextprotocol', 'apify.com', 'design-kit', 'press-kit',
     'scrapers', 'professional-services', 'challenge', 'challange', '1m-challenge', '1m-usd-challenge',
 
     // Apify platform resources
@@ -261,7 +261,7 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     'accessibility', 'imprint', 'impressum', 'trust', 'trust-center', 'security-center',
 
     // Brand protection / impersonation prevention
-    'verified', 'apify-support', 'apify-team', 'support-team', 'abuse',
+    'brand', 'verified', 'apify-support', 'apify-team', 'support-team', 'abuse',
 
     // Incidents / updates
     'outage', 'incident', 'incidents', 'what-is-new',

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -127,6 +127,11 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('karel')).toBe(false);
             expect(utils.isForbiddenUsername('karel1234')).toBe(false);
             expect(utils.isForbiddenUsername('karel.novak')).toBe(false);
+
+            // apify.com pattern (unescaped "." matches any character)
+            expect(utils.isForbiddenUsername('apify.com')).toBe(true);
+            expect(utils.isForbiddenUsername('apify_com')).toBe(true);
+            expect(utils.isForbiddenUsername('apifyxcom')).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary
Updated the forbidden usernames list to prevent registration of two additional reserved usernames that could conflict with Apify's brand protection and platform resources.

## Changes
- Added `'mcpc'` to the general forbidden usernames list (alongside existing `'mcp'` entry for Model Context Protocol related terms)
- Added `'brand'` to the brand protection/impersonation prevention section of forbidden usernames

## Details
These additions strengthen username reservation policies by:
1. Preventing potential confusion with MCP-related terminology through the `mcpc` variant
2. Protecting the `brand` namespace from being claimed by users, which could be used for impersonation or brand confusion

https://claude.ai/code/session_01SW4w6L2p91aVZ37NCGSk2H