### PR TITLE
chore: mathjs version upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10422,9 +10422,9 @@
             }
         },
         "node_modules/mathjs": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.1.1.tgz",
-            "integrity": "sha512-rM668DTtpSzMVoh/cKAllyQVEbBApM5g//IMGD8vD7YlrIz9ITRr3SrdhjaDxcBNTdyETWwPebj2unZyHD7ZdA==",
+            "version": "15.2.0",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+            "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime": "^7.26.10",
@@ -15667,7 +15667,7 @@
             "dependencies": {
                 "@apify/consts": "^2.52.1",
                 "@apify/log": "^2.5.35",
-                "mathjs": "^15.1.0"
+                "mathjs": "^15.2.0"
             }
         },
         "packages/consts": {

--- a/packages/actor-memory-expression/package.json
+++ b/packages/actor-memory-expression/package.json
@@ -50,6 +50,6 @@
     "dependencies": {
         "@apify/consts": "^2.52.1",
         "@apify/log": "^2.5.35",
-        "mathjs": "^15.1.0"
+        "mathjs": "^15.2.0"
     }
 }


### PR DESCRIPTION
This PR upgrades MathJS version to fix [vulnerability](https://github.com/apify/apify-core/security/dependabot/460).