### PR TITLE
feat: revisit input schema types export and fix missing editor option

### DIFF
--- a/packages/input_schema/src/index.ts
+++ b/packages/input_schema/src/index.ts
@@ -7,7 +7,6 @@ export {
     NumberFieldDefinition,
     ObjectFieldDefinition,
     ArrayFieldDefinition,
-
     ResourceFieldDefinition,
     ResourceArrayFieldDefinition,
 

--- a/packages/input_schema/src/index.ts
+++ b/packages/input_schema/src/index.ts
@@ -7,6 +7,7 @@ export {
     NumberFieldDefinition,
     ObjectFieldDefinition,
     ArrayFieldDefinition,
+
     ResourceFieldDefinition,
     ResourceArrayFieldDefinition,
 

--- a/packages/input_schema/src/index.ts
+++ b/packages/input_schema/src/index.ts
@@ -7,12 +7,13 @@ export {
     NumberFieldDefinition,
     ObjectFieldDefinition,
     ArrayFieldDefinition,
+
+    ResourceFieldDefinition,
+    ResourceArrayFieldDefinition,
+
     MixedFieldDefinition,
     FieldDefinition,
 
     InputSchema,
-
-    McpServer,
-    McpServerTools,
 } from './types';
 export * from './utilities';

--- a/packages/input_schema/src/types.ts
+++ b/packages/input_schema/src/types.ts
@@ -81,7 +81,7 @@ type StorageResourceFieldDefinition<T> = CommonResourceFieldDefinition<T> & {
     resourcePermissions?: ('READ' | 'WRITE')[];
 }
 
-export type McpServerTools = {
+type McpServerTools = {
     required?: string[];
     readOnly?: boolean;
     destructive?: boolean;
@@ -89,7 +89,7 @@ export type McpServerTools = {
     openWorld?: boolean;
 }
 
-export type McpServer = {
+type McpServer = {
     url: string;
     tools?: McpServerTools;
 }
@@ -105,6 +105,8 @@ type AnyResourceFieldDefinition<T> =
 
 export type ResourceFieldDefinition = AnyResourceFieldDefinition<string> & {
     type: 'string';
+    // Singular resource field also supports 'textfield' editor, unlike the array variant.
+    editor?: CommonResourceFieldDefinition<string>['editor'] | 'textfield';
 }
 
 export type ResourceArrayFieldDefinition = AnyResourceFieldDefinition<string[]> & {


### PR DESCRIPTION
Goal: expose only "complete" field definitions, no intermediate types via `@apify/input_schema`.

Additional fix: the type of singular ("string" type) resource input field lacks `textinput` editor. Added.