### PR TITLE
feat: Add forbidden usernames for AI agent and LLM-related files

### DIFF
--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -271,6 +271,7 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     // Special files
     'index', 'index\\.html', '(favicon\\.[a-z]+)', 'BingSiteAuth.xml', '(google.+\\.html)', 'robots\\.txt',
     '(sitemap\\.[a-z]+)', '(apple-touch-icon.*)', 'security-whitepaper\\.pdf', 'security\\.txt', 'llms\\.txt',
+    'llms-full\\.txt', 'AGENTS\\.md',
 
     // All hidden files
     '(\\..*)',

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -74,6 +74,10 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('index')).toBe(true);
             expect(utils.isForbiddenUsername('google6d0b9d7407741f6a.html')).toBe(true);
             expect(utils.isForbiddenUsername('BingSiteAuth.XML')).toBe(true);
+            expect(utils.isForbiddenUsername('llms.txt')).toBe(true);
+            expect(utils.isForbiddenUsername('llms-full.txt')).toBe(true);
+            expect(utils.isForbiddenUsername('AGENTS.md')).toBe(true);
+            expect(utils.isForbiddenUsername('agents.MD')).toBe(true);
 
             // All hidden files
             expect(utils.isForbiddenUsername('.hidden')).toBe(true);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -86,6 +86,7 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('..')).toBe(true);
             expect(utils.isForbiddenUsername('...')).toBe(true);
             expect(utils.isForbiddenUsername('.htaccess')).toBe(true);
+            expect(utils.isForbiddenUsername('.well-known')).toBe(true);
 
             // Strings not starting with letter or number
             expect(utils.isForbiddenUsername('_karlyolo')).toBe(true);


### PR DESCRIPTION
## Summary
This PR expands the list of forbidden usernames to include additional special files related to AI agents and LLM configurations, as well as the `.well-known` directory which is commonly used for web standards and security configurations.

## Key Changes
- Added `llms-full.txt` to forbidden usernames (LLM configuration file)
- Added `AGENTS.md` to forbidden usernames (case-insensitive, for AI agent documentation)
- Added `.well-known` to forbidden usernames (standard directory for web configurations like ACME challenges, security policies, etc.)
- Updated corresponding test cases to verify these new forbidden usernames are properly rejected

## Implementation Details
The changes follow the existing pattern in the `FORBIDDEN_USERNAMES_REGEXPS` array, using regex patterns to match filenames case-insensitively where appropriate. The `.well-known` entry uses the existing hidden file pattern `(\..*)` which already matches all dot-prefixed files and directories.

https://claude.ai/code/session_01V6hCX7q11X1kWN7CRjjXzQ