### PR TITLE
feat: add CLAUDE.md to forbidden usernames

### DIFF
--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -271,7 +271,7 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     // Special files
     'index', 'index\\.html', '(favicon\\.[a-z]+)', 'BingSiteAuth.xml', '(google.+\\.html)', 'robots\\.txt',
     '(sitemap\\.[a-z]+)', '(apple-touch-icon.*)', 'security-whitepaper\\.pdf', 'security\\.txt', 'llms\\.txt',
-    'llms-full\\.txt', 'AGENTS\\.md',
+    'llms-full\\.txt', 'AGENTS\\.md', 'CLAUDE\\.md',
 
     // All hidden files
     '(\\..*)',

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -78,6 +78,8 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('llms-full.txt')).toBe(true);
             expect(utils.isForbiddenUsername('AGENTS.md')).toBe(true);
             expect(utils.isForbiddenUsername('agents.MD')).toBe(true);
+            expect(utils.isForbiddenUsername('CLAUDE.md')).toBe(true);
+            expect(utils.isForbiddenUsername('claude.MD')).toBe(true);
 
             // All hidden files
             expect(utils.isForbiddenUsername('.hidden')).toBe(true);


### PR DESCRIPTION
## Summary
This PR adds `CLAUDE.md` to the list of forbidden usernames to prevent users from registering usernames that would conflict with Claude Code configuration files on web URLs.

Similar to #621 which added `AGENTS.md` and `llms-full.txt`.

## Key Changes
- Added `CLAUDE.md` to forbidden usernames (case-insensitive, for Claude Code configuration files)
- Added corresponding test cases to verify `CLAUDE.md` and `claude.MD` are properly rejected

## Slack Thread
https://apify.slack.com/archives/C0ANGNWT85T/p1777020731104349?thread_ts=1776943682.809139&cid=C0ANGNWT85T

https://claude.ai/code/session_01GPyCtsQ8YkKtuhAeCDLaXB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPyCtsQ8YkKtuhAeCDLaXB)_