### PR TITLE
ci: use workspace protocol for internal `@apify/*` deps

### DIFF
--- a/packages/actor-memory-expression/package.json
+++ b/packages/actor-memory-expression/package.json
@@ -48,8 +48,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/consts": "^2.52.1",
-        "@apify/log": "^2.5.35",
+        "@apify/consts": "workspace:^",
+        "@apify/log": "workspace:^",
         "mathjs": "^15.2.0"
     }
 }

--- a/packages/input_schema/package.json
+++ b/packages/input_schema/package.json
@@ -48,9 +48,9 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/consts": "^2.52.1",
-        "@apify/input_secrets": "^1.2.32",
-        "@apify/json_schemas": "^0.16.3",
+        "@apify/consts": "workspace:^",
+        "@apify/input_secrets": "workspace:^",
+        "@apify/json_schemas": "workspace:^",
         "acorn-loose": "^8.4.0",
         "countries-list": "^3.0.0"
     },

--- a/packages/input_secrets/package.json
+++ b/packages/input_secrets/package.json
@@ -44,8 +44,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/log": "^2.5.35",
-        "@apify/utilities": "^2.29.0",
+        "@apify/log": "workspace:^",
+        "@apify/utilities": "workspace:^",
         "ow": "^0.28.2"
     }
 }

--- a/packages/json_schemas/package.json
+++ b/packages/json_schemas/package.json
@@ -55,7 +55,7 @@
         "tsx": "^4.6.2"
     },
     "dependencies": {
-        "@apify/consts": "^2.52.1",
+        "@apify/consts": "workspace:^",
         "ajv": "^8.17.1"
     }
 }

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -48,7 +48,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/consts": "^2.52.1",
+        "@apify/consts": "workspace:^",
         "ansi-colors": "^4.1.1"
     }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -48,8 +48,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/consts": "^2.52.1",
-        "@apify/utilities": "^2.29.0",
+        "@apify/consts": "workspace:^",
+        "@apify/utilities": "workspace:^",
         "marked": "^15.0.0",
         "match-all": "^1.2.6"
     },

--- a/packages/pseudo_url/package.json
+++ b/packages/pseudo_url/package.json
@@ -44,6 +44,6 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/log": "^2.5.35"
+        "@apify/log": "workspace:^"
     }
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -48,8 +48,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@apify/consts": "^2.52.1",
-        "@apify/log": "^2.5.35"
+        "@apify/consts": "workspace:^",
+        "@apify/log": "workspace:^"
     },
     "devDependencies": {
         "@types/create-hmac": "^1.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,11 +84,11 @@ importers:
   packages/actor-memory-expression:
     dependencies:
       '@apify/consts':
-        specifier: ^2.52.1
-        version: 2.52.1
+        specifier: workspace:^
+        version: link:../consts
       '@apify/log':
-        specifier: ^2.5.35
-        version: 2.5.35
+        specifier: workspace:^
+        version: link:../log
       mathjs:
         specifier: ^15.2.0
         version: 15.2.0
@@ -118,14 +118,14 @@ importers:
   packages/input_schema:
     dependencies:
       '@apify/consts':
-        specifier: ^2.52.1
-        version: 2.52.1
+        specifier: workspace:^
+        version: link:../consts
       '@apify/input_secrets':
-        specifier: ^1.2.32
-        version: 1.2.32
+        specifier: workspace:^
+        version: link:../input_secrets
       '@apify/json_schemas':
-        specifier: ^0.16.3
-        version: 0.16.3
+        specifier: workspace:^
+        version: link:../json_schemas
       acorn-loose:
         specifier: ^8.4.0
         version: 8.5.2
@@ -143,11 +143,11 @@ importers:
   packages/input_secrets:
     dependencies:
       '@apify/log':
-        specifier: ^2.5.35
-        version: 2.5.35
+        specifier: workspace:^
+        version: link:../log
       '@apify/utilities':
-        specifier: ^2.29.0
-        version: 2.29.0
+        specifier: workspace:^
+        version: link:../utilities
       ow:
         specifier: ^0.28.2
         version: 0.28.2
@@ -155,8 +155,8 @@ importers:
   packages/json_schemas:
     dependencies:
       '@apify/consts':
-        specifier: ^2.52.1
-        version: 2.52.1
+        specifier: workspace:^
+        version: link:../consts
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
@@ -177,8 +177,8 @@ importers:
   packages/log:
     dependencies:
       '@apify/consts':
-        specifier: ^2.52.1
-        version: 2.52.1
+        specifier: workspace:^
+        version: link:../consts
       ansi-colors:
         specifier: ^4.1.1
         version: 4.1.3
@@ -186,11 +186,11 @@ importers:
   packages/markdown:
     dependencies:
       '@apify/consts':
-        specifier: ^2.52.1
-        version: 2.52.1
+        specifier: workspace:^
+        version: link:../consts
       '@apify/utilities':
-        specifier: ^2.29.0
-        version: 2.29.0
+        specifier: workspace:^
+        version: link:../utilities
       marked:
         specifier: ^15.0.0
         version: 15.0.12
@@ -211,28 +211,25 @@ importers:
   packages/pseudo_url:
     dependencies:
       '@apify/log':
-        specifier: ^2.5.35
-        version: 2.5.35
+        specifier: workspace:^
+        version: link:../log
 
   packages/timeout: {}
 
   packages/utilities:
     dependencies:
       '@apify/consts':
-        specifier: ^2.52.1
-        version: 2.52.1
+        specifier: workspace:^
+        version: link:../consts
       '@apify/log':
-        specifier: ^2.5.35
-        version: 2.5.35
+        specifier: workspace:^
+        version: link:../log
     devDependencies:
       '@types/create-hmac':
         specifier: ^1.1.0
         version: 1.1.3
 
 packages:
-
-  '@apify/consts@2.52.1':
-    resolution: {integrity: sha512-Nhal8FiIgAw5ylVL4U2DAeJJyKow0bFObAX/og5BJjB9xJ2csQcyVAx4ChnO7XOaeRU8HbRn9u0QUGzPt5NNqA==}
 
   '@apify/eslint-config@2.0.6':
     resolution: {integrity: sha512-8Ai9bHAB3wtVOupZO0TwrM3ZaEUdh//764DEw0uOxfp71xOApS3NdAYzy/6B22jnpd/cnOXqyz80kXLQiqicAQ==}
@@ -252,18 +249,6 @@ packages:
         optional: true
       typescript-eslint:
         optional: true
-
-  '@apify/input_secrets@1.2.32':
-    resolution: {integrity: sha512-oDV/P0Oz5t2zJziqi557+uCXwPerBgX+Hh+m3CA6M6aTCqmDpxWiIYAItt+/L0a4LUEIx5WwT45/bogLa23zRA==}
-
-  '@apify/json_schemas@0.16.3':
-    resolution: {integrity: sha512-yLe7CSKGInMfs4gGlDJZcu9dledrX0hlXmgt6cMaaPU1QaPABPsSLZPvyxmPzzEoddvu1nrpjKlWbuwW0Z+1zw==}
-
-  '@apify/log@2.5.35':
-    resolution: {integrity: sha512-dJM9RkA9yD7kew5oU3qxLaoB4hFHB7FF47TI0STJVmz0cUa8cXWer4DpJkvUA52lrVNQGsOurCo3kGQWzfg/9w==}
-
-  '@apify/utilities@2.29.0':
-    resolution: {integrity: sha512-Yx+NoTWKD7gf/x4DhNkqiWcHLM2SuNd9kosudMboLLNHAN5dbzgMqLhH5s2WSERizjWRKsHMP7eINMClPOXTPQ==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4700,8 +4685,6 @@ packages:
 
 snapshots:
 
-  '@apify/consts@2.52.1': {}
-
   '@apify/eslint-config@2.0.6(@eslint/js@9.39.4)(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript-eslint@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 9.39.4
@@ -4715,27 +4698,6 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - supports-color
-
-  '@apify/input_secrets@1.2.32':
-    dependencies:
-      '@apify/log': 2.5.35
-      '@apify/utilities': 2.29.0
-      ow: 0.28.2
-
-  '@apify/json_schemas@0.16.3':
-    dependencies:
-      '@apify/consts': 2.52.1
-      ajv: 8.18.0
-
-  '@apify/log@2.5.35':
-    dependencies:
-      '@apify/consts': 2.52.1
-      ansi-colors: 4.1.3
-
-  '@apify/utilities@2.29.0':
-    dependencies:
-      '@apify/consts': 2.52.1
-      '@apify/log': 2.5.35
 
   '@babel/code-frame@7.29.0':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the publish workflow failure that surfaced after the pnpm migration (#616) merged.

### What broke

After lerna bumped versions in [run 25099449315](https://github.com/apify/apify-shared-js/actions/runs/25099449315/job/73544484277), it called `pnpm install --lockfile-only --ignore-scripts` to refresh the lockfile. pnpm then tried to fetch the newly bumped versions (e.g. `@apify/consts@^2.52.2`) from the registry — which don't exist yet because lerna hasn't published them. The publish step exited 1 with `ERR_PNPM_NO_MATCHING_VERSION`.

### Fix

Switches every internal `@apify/<package>` dependency from a registry range (e.g. `^2.52.1`) to the pnpm [`workspace:^` protocol](https://pnpm.io/workspaces#workspace-protocol-workspace). pnpm now resolves them as workspace links, and lerna replaces `workspace:^` with the actual published version at publish time — same pattern apify-storage-local-js and crawlee already use.

Lockfile diff confirms the switch is purely the resolution mechanism (`version: 2.52.1` → `version: link:../consts`); no transitive dep changes.

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 459/459 passing
- [x] `pnpm build` — all 15 packages built
- [ ] Next merge to master triggers a successful publish