### PR TITLE
chore: ignore oxfmt mass reformat in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Mass reformat with oxfmt (#624)
+a348870edc1935f7bb37fe9a25b2c67e12fc6917


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` pointing at the squash-merge commit of #624 (oxfmt mass reformat) so `git blame` skips that commit and attributes lines to their actual authors.

To opt in locally:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

GitHub's blame UI applies it automatically.