### PR TITLE
chore: drop redundant oxfmt options that .editorconfig already provides

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,4 @@
 {
-    "tabWidth": 4,
-    "singleQuote": true,
-    "trailingComma": "all",
     "printWidth": 120,
     "ignorePatterns": [
         "**/*.md",


### PR DESCRIPTION
## Summary

oxfmt reads `.editorconfig`, so `tabWidth` and `singleQuote` in `.oxfmtrc.json` were duplicating the existing `indent_size = 4` / `quote_type = single` from this repo's `.editorconfig`. Drop them — single source of truth, no drift.

Also dropping `trailingComma: "all"` since [it's the default](https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html#trailingcomma).

`printWidth` stays in `.oxfmtrc.json` (no editorconfig equivalent we want to enforce).

Verified locally: `pnpm format:check` still clean — the diff is purely the removed lines.