### PR TITLE
fix: drop only-allow preinstall, enforce pnpm via devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
         "lint": "oxlint --type-aware",
         "lint:fix": "oxlint --type-aware --fix",
         "format": "oxfmt",
-        "format:check": "oxfmt --check",
-        "preinstall": "npx only-allow pnpm"
+        "format:check": "oxfmt --check"
     },
     "commitlint": {
         "extends": [
@@ -74,5 +73,12 @@
         "underscore": "^1.13.7",
         "vitest": "^4.1.4"
     },
-    "packageManager": "pnpm@10.24.0"
+    "packageManager": "pnpm@10.33.4",
+    "devEngines": {
+        "packageManager": {
+            "name": "pnpm",
+            "version": "10.33.4",
+            "onFail": "warn"
+        }
+    }
 }


### PR DESCRIPTION
The `preinstall: npx only-allow pnpm` script ships in the published npm tarball and fires when downstream consumers install this package via npm/yarn. In the `npm install -g apify-cli` flow the npx bootstrap of `only-allow` fails to put the binary on PATH in time:
- Linux: `sh: 1: only-allow: not found` (exit 127)
- Windows: `'only-allow' is not recognized as an internal or external command` (exit 1)

Replaces with `devEngines.packageManager` (Node 22+/npm 10+) with `onFail: "warn"`. This keeps the developer-visible signal without breaking CI steps that indirectly invoke npm (pnpm v10 shells to npm for `pnpm version`, `pnpm config`, etc.).

`devEngines` is only checked at the package's own repo root, never on transitive installs, so downstream consumers are unaffected.

Mirrors apify/apify-client-js#895 + #896.