### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -43,20 +43,9 @@ jobs:
                   GIT_COMMITTER_NAME: Apify Release Bot
                   GIT_AUTHOR_EMAIL: noreply@apify.com
                   GIT_COMMITTER_EMAIL: noreply@apify.com
-            - name: Stage changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit changes
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore: update root lock file and changelog [skip ci]'
+                  message: 'chore: update root lock file and changelog [skip ci]'
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -43,10 +43,20 @@ jobs:
                   GIT_COMMITTER_NAME: Apify Release Bot
                   GIT_AUTHOR_EMAIL: noreply@apify.com
                   GIT_COMMITTER_EMAIL: noreply@apify.com
+            - name: Stage changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit changes
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'chore: update root lock file and changelog [skip ci]'
-                  pull: '--rebase --autostash'
+                  commit-message: 'chore: update root lock file and changelog [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.