### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
             - name: Build module
               run: pnpm build
             - name: Publish to NPM

--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -24,7 +24,7 @@ jobs:
                 with:
                     node-version: ${{ matrix.node-version }}
             -   name: Install pnpm and dependencies
-                uses: apify/workflows/pnpm-install@main
+                uses: apify/actions/pnpm-install@v1.0.0
             -   name: Run Tests
                 run: pnpm test
 
@@ -39,7 +39,7 @@ jobs:
                 with:
                     node-version: 24
             -   name: Install pnpm and dependencies
-                uses: apify/workflows/pnpm-install@main
+                uses: apify/actions/pnpm-install@v1.0.0
             -   run: pnpm build
 
             -   name: Check build consistency
@@ -60,7 +60,7 @@ jobs:
                 with:
                     node-version: 24
             -   name: Install pnpm and dependencies
-                uses: apify/workflows/pnpm-install@main
+                uses: apify/actions/pnpm-install@v1.0.0
             -   run: pnpm lint
 
     format-check:
@@ -74,7 +74,7 @@ jobs:
                 with:
                     node-version: 24
             -   name: Install pnpm and dependencies
-                uses: apify/workflows/pnpm-install@main
+                uses: apify/actions/pnpm-install@v1.0.0
             -   run: pnpm format:check
 
     publish:
@@ -90,14 +90,14 @@ jobs:
                 with:
                     node-version: 24
             -   name: Install pnpm and dependencies
-                uses: apify/workflows/pnpm-install@main
+                uses: apify/actions/pnpm-install@v1.0.0
             -   name: Check for changes
                 id: changed_packages
                 run: |
                     echo "changed_packages=$(pnpm exec lerna changed -p | wc -l | xargs)" | tee -a $GITHUB_OUTPUT
             -   name: Execute publish workflow
                 if: steps.changed_packages.outputs.changed_packages != '0'
-                uses: apify/workflows/execute-workflow@main
+                uses: apify/actions/execute-workflow@v1.0.0
                 with:
                     workflow: publish_to_npm.yaml
                     inputs: >


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.