### PR TITLE
feat: Add new forbidden username filters

### DIFF
--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -670,8 +670,19 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     // Username starting with xxx-
     '(xxx-.*)',
 
-    // Username containing porn
+    // Usernames containing inappropriate/adult content keywords
     '(.*porn.*)',
+    '(.*penis.*)',
+    '(.*vagina.*)',
+    '(.*cock.*)',
+    '(.*anus.*)',
+    '(.*dick.*)',
+    '(.*pussy.*)',
+    '(.*dildo.*)',
+    '(.*nude.*)',
+    '(.*naked.*)',
+    '(.*nsfw.*)',
+    '(.*hentai.*)',
 
     // Username starting with install-cli. (see https://docs.apify.com/cli/docs/installation)
     '(install-cli\\..*)',

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -670,6 +670,9 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     // Username starting with xxx-
     '(xxx-.*)',
 
+    // Username containing porn
+    '(.*porn.*)',
+
     // Username starting with install-cli. (see https://docs.apify.com/cli/docs/installation)
     '(install-cli\\..*)',
 

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -671,15 +671,13 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     '(xxx-.*)',
 
     // Usernames containing inappropriate/adult content keywords
+    // NOTE: Some obvious words (cock, dick, anus, pussy, nude) are intentionally
+    // omitted due to false positives with surnames (Dickens, Hancock, Dickson)
+    // and legitimate words (Uranus, Janus, pussycat, denude, Nudelman).
     '(.*porn.*)',
     '(.*penis.*)',
     '(.*vagina.*)',
-    '(.*cock.*)',
-    '(.*anus.*)',
-    '(.*dick.*)',
-    '(.*pussy.*)',
     '(.*dildo.*)',
-    '(.*nude.*)',
     '(.*naked.*)',
     '(.*nsfw.*)',
     '(.*hentai.*)',

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -683,6 +683,14 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     '(.*naked.*)',
     '(.*nsfw.*)',
     '(.*hentai.*)',
+    '(.*cunt.*)',
+    '(.*fuck.*)',
+    '(.*shit.*)',
+    '(.*bitch.*)',
+    '(.*slut.*)',
+    '(.*whore.*)',
+    '(.*boob.*)',
+    '(.*tits.*)',
 
     // Username starting with install-cli. (see https://docs.apify.com/cli/docs/installation)
     '(install-cli\\..*)',

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -1297,6 +1297,11 @@ const FORBIDDEN_REGEXP = new RegExp(`^(${ANONYMOUS_USERNAME}|${FORBIDDEN_USERNAM
 /**
  * Checks whether username is listed in FORBIDDEN_USERNAMES
  * or matches any root route path.
+ *
+ * NOTE: The forbidden list may expand over time, so a username that was
+ * previously permitted may later become forbidden. Use this function only
+ * when validating a username change, not as part of normal authentication
+ * or authorization flow.
  */
 export function isForbiddenUsername(username: string): boolean {
     return !!username.match(APIFY_ID_REGEX) || !!username.match(FORBIDDEN_REGEXP);

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -671,9 +671,6 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     '(xxx-.*)',
 
     // Usernames containing inappropriate/adult content keywords
-    // NOTE: Some obvious words are intentionally omitted due to false positives:
-    // cock, dick, anus, pussy, nude (surnames: Dickens, Hancock; words: Uranus, Janus, pussycat)
-    // penis (Penistone - real UK town/surname), naked (snaked, snakedance)
     '(.*porn.*)',
     '(.*vagina.*)',
     '(.*dildo.*)',
@@ -687,6 +684,15 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     '(.*whore.*)',
     '(.*boob.*)',
     '(.*tits.*)',
+    // Words that require non-letter boundaries to avoid false positives with
+    // legitimate surnames (Dickens, Hancock, Nudelman) and words (Uranus, pussycat, snaked)
+    '((.+[^a-z]|)cock([^a-z].+|))',
+    '((.+[^a-z]|)dick([^a-z].+|))',
+    '((.+[^a-z]|)anus([^a-z].+|))',
+    '((.+[^a-z]|)pussy([^a-z].+|))',
+    '((.+[^a-z]|)nude([^a-z].+|))',
+    '((.+[^a-z]|)penis([^a-z].+|))',
+    '((.+[^a-z]|)naked([^a-z].+|))',
 
     // Username starting with install-cli. (see https://docs.apify.com/cli/docs/installation)
     '(install-cli\\..*)',

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -671,14 +671,12 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     '(xxx-.*)',
 
     // Usernames containing inappropriate/adult content keywords
-    // NOTE: Some obvious words (cock, dick, anus, pussy, nude) are intentionally
-    // omitted due to false positives with surnames (Dickens, Hancock, Dickson)
-    // and legitimate words (Uranus, Janus, pussycat, denude, Nudelman).
+    // NOTE: Some obvious words are intentionally omitted due to false positives:
+    // cock, dick, anus, pussy, nude (surnames: Dickens, Hancock; words: Uranus, Janus, pussycat)
+    // penis (Penistone - real UK town/surname), naked (snaked, snakedance)
     '(.*porn.*)',
-    '(.*penis.*)',
     '(.*vagina.*)',
     '(.*dildo.*)',
-    '(.*naked.*)',
     '(.*nsfw.*)',
     '(.*hentai.*)',
     '(.*cunt.*)',

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -154,6 +154,14 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('naked-pics')).toBe(true);
             expect(utils.isForbiddenUsername('nsfw-content')).toBe(true);
             expect(utils.isForbiddenUsername('hentai-fan')).toBe(true);
+            expect(utils.isForbiddenUsername('cunt123')).toBe(true);
+            expect(utils.isForbiddenUsername('fuckyou')).toBe(true);
+            expect(utils.isForbiddenUsername('bullshit')).toBe(true);
+            expect(utils.isForbiddenUsername('bitch-mode')).toBe(true);
+            expect(utils.isForbiddenUsername('slutty')).toBe(true);
+            expect(utils.isForbiddenUsername('whore-house')).toBe(true);
+            expect(utils.isForbiddenUsername('boobs')).toBe(true);
+            expect(utils.isForbiddenUsername('bigtits')).toBe(true);
 
             // Test valid usernames
             expect(!utils.isForbiddenUsername('apify')).toBe(true);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -143,10 +143,8 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('top-porner')).toBe(true);
             expect(utils.isForbiddenUsername('my-porn-site')).toBe(true);
             expect(utils.isForbiddenUsername('PORN')).toBe(true);
-            expect(utils.isForbiddenUsername('penis123')).toBe(true);
             expect(utils.isForbiddenUsername('vagina-lover')).toBe(true);
             expect(utils.isForbiddenUsername('dildo-shop')).toBe(true);
-            expect(utils.isForbiddenUsername('naked-pics')).toBe(true);
             expect(utils.isForbiddenUsername('nsfw-content')).toBe(true);
             expect(utils.isForbiddenUsername('hentai-fan')).toBe(true);
             expect(utils.isForbiddenUsername('cunt123')).toBe(true);
@@ -167,6 +165,8 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('janus')).toBe(false);
             expect(utils.isForbiddenUsername('pussycat')).toBe(false);
             expect(utils.isForbiddenUsername('nudelman')).toBe(false);
+            expect(utils.isForbiddenUsername('penistone')).toBe(false);
+            expect(utils.isForbiddenUsername('snaked')).toBe(false);
 
             // Test valid usernames
             expect(!utils.isForbiddenUsername('apify')).toBe(true);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -145,12 +145,7 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('PORN')).toBe(true);
             expect(utils.isForbiddenUsername('penis123')).toBe(true);
             expect(utils.isForbiddenUsername('vagina-lover')).toBe(true);
-            expect(utils.isForbiddenUsername('bigcock')).toBe(true);
-            expect(utils.isForbiddenUsername('anus-man')).toBe(true);
-            expect(utils.isForbiddenUsername('dickpics')).toBe(true);
-            expect(utils.isForbiddenUsername('pussy-cat')).toBe(true);
             expect(utils.isForbiddenUsername('dildo-shop')).toBe(true);
-            expect(utils.isForbiddenUsername('nudemodels')).toBe(true);
             expect(utils.isForbiddenUsername('naked-pics')).toBe(true);
             expect(utils.isForbiddenUsername('nsfw-content')).toBe(true);
             expect(utils.isForbiddenUsername('hentai-fan')).toBe(true);
@@ -162,6 +157,16 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('whore-house')).toBe(true);
             expect(utils.isForbiddenUsername('boobs')).toBe(true);
             expect(utils.isForbiddenUsername('bigtits')).toBe(true);
+
+            // Verify no false positives for common surnames and legitimate words
+            expect(utils.isForbiddenUsername('dickens')).toBe(false);
+            expect(utils.isForbiddenUsername('dickson')).toBe(false);
+            expect(utils.isForbiddenUsername('hancock')).toBe(false);
+            expect(utils.isForbiddenUsername('peacock')).toBe(false);
+            expect(utils.isForbiddenUsername('uranus')).toBe(false);
+            expect(utils.isForbiddenUsername('janus')).toBe(false);
+            expect(utils.isForbiddenUsername('pussycat')).toBe(false);
+            expect(utils.isForbiddenUsername('nudelman')).toBe(false);
 
             // Test valid usernames
             expect(!utils.isForbiddenUsername('apify')).toBe(true);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -137,6 +137,13 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('karl__yolo')).toBe(true);
             expect(utils.isForbiddenUsername('karl__.yolo')).toBe(true);
 
+            // Usernames containing porn
+            expect(utils.isForbiddenUsername('porn')).toBe(true);
+            expect(utils.isForbiddenUsername('pornvidsdownload')).toBe(true);
+            expect(utils.isForbiddenUsername('top-porner')).toBe(true);
+            expect(utils.isForbiddenUsername('my-porn-site')).toBe(true);
+            expect(utils.isForbiddenUsername('PORN')).toBe(true);
+
             // Test valid usernames
             expect(!utils.isForbiddenUsername('apify')).toBe(true);
             expect(!utils.isForbiddenUsername('APIFY')).toBe(true);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -137,12 +137,23 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('karl__yolo')).toBe(true);
             expect(utils.isForbiddenUsername('karl__.yolo')).toBe(true);
 
-            // Usernames containing porn
+            // Usernames containing inappropriate/adult content keywords
             expect(utils.isForbiddenUsername('porn')).toBe(true);
             expect(utils.isForbiddenUsername('pornvidsdownload')).toBe(true);
             expect(utils.isForbiddenUsername('top-porner')).toBe(true);
             expect(utils.isForbiddenUsername('my-porn-site')).toBe(true);
             expect(utils.isForbiddenUsername('PORN')).toBe(true);
+            expect(utils.isForbiddenUsername('penis123')).toBe(true);
+            expect(utils.isForbiddenUsername('vagina-lover')).toBe(true);
+            expect(utils.isForbiddenUsername('bigcock')).toBe(true);
+            expect(utils.isForbiddenUsername('anus-man')).toBe(true);
+            expect(utils.isForbiddenUsername('dickpics')).toBe(true);
+            expect(utils.isForbiddenUsername('pussy-cat')).toBe(true);
+            expect(utils.isForbiddenUsername('dildo-shop')).toBe(true);
+            expect(utils.isForbiddenUsername('nudemodels')).toBe(true);
+            expect(utils.isForbiddenUsername('naked-pics')).toBe(true);
+            expect(utils.isForbiddenUsername('nsfw-content')).toBe(true);
+            expect(utils.isForbiddenUsername('hentai-fan')).toBe(true);
 
             // Test valid usernames
             expect(!utils.isForbiddenUsername('apify')).toBe(true);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -156,14 +156,33 @@ describe('utilities', () => {
             expect(utils.isForbiddenUsername('boobs')).toBe(true);
             expect(utils.isForbiddenUsername('bigtits')).toBe(true);
 
+            // Boundary-based patterns (blocked when not embedded in legitimate words)
+            expect(utils.isForbiddenUsername('cock')).toBe(true);
+            expect(utils.isForbiddenUsername('big-cock')).toBe(true);
+            expect(utils.isForbiddenUsername('cock-lover')).toBe(true);
+            expect(utils.isForbiddenUsername('dick')).toBe(true);
+            expect(utils.isForbiddenUsername('my-dick')).toBe(true);
+            expect(utils.isForbiddenUsername('anus')).toBe(true);
+            expect(utils.isForbiddenUsername('my-anus')).toBe(true);
+            expect(utils.isForbiddenUsername('pussy')).toBe(true);
+            expect(utils.isForbiddenUsername('wet-pussy')).toBe(true);
+            expect(utils.isForbiddenUsername('nude')).toBe(true);
+            expect(utils.isForbiddenUsername('nude-pics')).toBe(true);
+            expect(utils.isForbiddenUsername('penis')).toBe(true);
+            expect(utils.isForbiddenUsername('big-penis')).toBe(true);
+            expect(utils.isForbiddenUsername('naked')).toBe(true);
+            expect(utils.isForbiddenUsername('naked-pics')).toBe(true);
+
             // Verify no false positives for common surnames and legitimate words
             expect(utils.isForbiddenUsername('dickens')).toBe(false);
             expect(utils.isForbiddenUsername('dickson')).toBe(false);
             expect(utils.isForbiddenUsername('hancock')).toBe(false);
             expect(utils.isForbiddenUsername('peacock')).toBe(false);
+            expect(utils.isForbiddenUsername('cockpit')).toBe(false);
             expect(utils.isForbiddenUsername('uranus')).toBe(false);
             expect(utils.isForbiddenUsername('janus')).toBe(false);
             expect(utils.isForbiddenUsername('pussycat')).toBe(false);
+            expect(utils.isForbiddenUsername('pussywillow')).toBe(false);
             expect(utils.isForbiddenUsername('nudelman')).toBe(false);
             expect(utils.isForbiddenUsername('penistone')).toBe(false);
             expect(utils.isForbiddenUsername('snaked')).toBe(false);


### PR DESCRIPTION
Extends the forbidden usernames validation to reject usernames containing a couple of dirty keywords.

https://claude.ai/code/session_01MW39FcuEYJkGQwkGp3xBiJ