### PR TITLE
fix: enforce strict `APIFY_ID_REGEX` validation with anchors

### DIFF
--- a/packages/consts/src/regexs.ts
+++ b/packages/consts/src/regexs.ts
@@ -160,5 +160,4 @@ export const CONTACT_LINK_REGEX = /^(mailto|tel|sms):.*$/i;
  * because we have user objects with that in database.
  * @type {RegExp}
  */
-// TODO: @fnesveda [2022-08-15] revert to stricter regex /^[a-zA-Z0-9]{17}$/ once we properly delete user yZtyxMUADJHyInTIdl
-export const APIFY_ID_REGEX = /[a-zA-Z0-9]{17}/;
+export const APIFY_ID_REGEX = /^[a-zA-Z0-9]{17}$/;

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -58,14 +58,23 @@ describe('consts', () => {
             const testingStrings = {
                 valid: ['S64xo2hmHBFHbqZQq', 'Z7rgePnfc04QHshc2'],
                 invalid: [
-                    // Invalid length
+                    // Too short
                     'Z7rgePnfc04QHshc',
+                    // Too long
+                    'Z7rgePnfc04QHshc2X',
+                    'yZtyxMUADJHyInTIdl',
                     // Invalid chars
                     '_7rgePnfc04QHshc2',
                     '-7rgePnfc04QHshc2',
                     '~7rgePnfc04QHshc2',
                     '}7rgePnfc04QHshc2',
                     '(7rgePnfc04QHshc2',
+                    // Valid 17-char ID embedded in a larger string (must be rejected by the anchored regex)
+                    ' S64xo2hmHBFHbqZQq',
+                    'S64xo2hmHBFHbqZQq ',
+                    'xS64xo2hmHBFHbqZQqx',
+                    // Empty string
+                    '',
                 ],
             };
             testingStrings.valid.forEach((str) => {


### PR DESCRIPTION
Restores `APIFY_ID_REGEX` to the anchored form `/^[a-zA-Z0-9]{17}$/` (resolving the long-standing TODO) and adds test coverage for inputs that only the anchored regex rejects: 18+ char strings, embedded 17-char matches, and the empty string.

https://claude.ai/code/session_01Eay2aTeQ79xWdQguqE6n27

Seems we forgot to properly fix this old ducktape. I [asked Claude](https://claude.ai/code/session_01Rb1giLNkxoisjTWG4qsjUX) to research uses of `APIFY_ID_REGEX` in apify-core and it says it's safe. User yZtyxMUADJHyInTIdl is completely deleted, and there are no others with incorrect ID in the database.

There are a few other places where this constant is used, but it looks safe: https://github.com/search?q=org%3Aapify+%22APIFY_ID_REGEX%22&type=code