### PR TITLE
chore: added mcp origin header value

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -75,6 +75,7 @@ export const META_ORIGINS = {
     CLI: 'CLI', // Job started by apify CLI
     STANDBY: 'STANDBY', // Job started by Actor Standby
     CI: 'CI', // Job started from a CI/CD pipeline (e.g. GitHub Actions)
+    MCP: 'MCP', // Job started trough apify client triggered from apify-mcp-server
 } as const;
 
 /**


### PR DESCRIPTION
The header was addded in mcp server: https://github.com/apify/apify-mcp-server/pull/835

Since I need to use the mcp value, to keep things clean, i need to add the value to the enum