### PR TITLE
feat: add forbidden usernames for creator and community routes

### DIFF
--- a/packages/utilities/src/usernames.ts
+++ b/packages/utilities/src/usernames.ts
@@ -231,6 +231,7 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     '1m-usd-challenge',
     'contact-sales',
     'creator',
+    'creators',
     'creator-plan',
     'request-an-integration',
     'whitepaper',

--- a/test/usernames.test.ts
+++ b/test/usernames.test.ts
@@ -53,7 +53,10 @@ describe('isForbiddenUsername()', () => {
 
         // Apify-specific routes / features
         expect(isForbiddenUsername('contact-sales')).toBe(true);
+        expect(isForbiddenUsername('creator')).toBe(true);
+        expect(isForbiddenUsername('creators')).toBe(true);
         expect(isForbiddenUsername('creator-plan')).toBe(true);
+        expect(isForbiddenUsername('community')).toBe(true);
         expect(isForbiddenUsername('standby')).toBe(true);
         expect(isForbiddenUsername('pay-per-event')).toBe(true);
         expect(isForbiddenUsername('compute-unit')).toBe(true);


### PR DESCRIPTION
Adds the plural `creators` to the forbidden usernames list (`creator` and `community` were already blocked) and adds test coverage for all three.

https://claude.ai/code/session_018U5hkuvJWh1e6dVJp3Ap6J