### PR TITLE
fix(json_schemas): reject empty key/keyPrefix in KVS collection schema

### DIFF
--- a/packages/json_schemas/output/actor.ide.json
+++ b/packages/json_schemas/output/actor.ide.json
@@ -5379,12 +5379,14 @@
                                 },
                                 "keyPrefix": {
                                     "type": "string",
+                                    "minLength": 1,
                                     "description": "Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is mutually exclusive with key.",
                                     "x-intellij-html-description": "<p>Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is\nmutually exclusive with <code>key</code>.</p>",
                                     "markdownDescription": "Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is\nmutually exclusive with `key`."
                                 },
                                 "key": {
                                     "type": "string",
+                                    "minLength": 1,
                                     "description": "Exact key for a single file in the collection. This is used when a collection contains only one specific file. This attribute is mutually exclusive with keyPrefix.",
                                     "x-intellij-html-description": "<p>Exact key for a single file in the collection. This is used when a collection contains only one specific file.\nThis attribute is mutually exclusive with <code>keyPrefix</code>.</p>",
                                     "markdownDescription": "Exact key for a single file in the collection. This is used when a collection contains only one specific file.\nThis attribute is mutually exclusive with `keyPrefix`."

--- a/packages/json_schemas/output/key-value-store.ide.json
+++ b/packages/json_schemas/output/key-value-store.ide.json
@@ -62,12 +62,14 @@
                         },
                         "keyPrefix": {
                             "type": "string",
+                            "minLength": 1,
                             "description": "Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is mutually exclusive with key.",
                             "x-intellij-html-description": "<p>Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is\nmutually exclusive with <code>key</code>.</p>",
                             "markdownDescription": "Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is\nmutually exclusive with `key`."
                         },
                         "key": {
                             "type": "string",
+                            "minLength": 1,
                             "description": "Exact key for a single file in the collection. This is used when a collection contains only one specific file. This attribute is mutually exclusive with keyPrefix.",
                             "x-intellij-html-description": "<p>Exact key for a single file in the collection. This is used when a collection contains only one specific file.\nThis attribute is mutually exclusive with <code>keyPrefix</code>.</p>",
                             "markdownDescription": "Exact key for a single file in the collection. This is used when a collection contains only one specific file.\nThis attribute is mutually exclusive with `keyPrefix`."

--- a/packages/json_schemas/output/key-value-store.json
+++ b/packages/json_schemas/output/key-value-store.json
@@ -63,12 +63,14 @@
                         },
                         "keyPrefix": {
                             "type": "string",
+                            "minLength": 1,
                             "description": "Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is mutually exclusive with key.",
                             "x-intellij-html-description": "<p>Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is\nmutually exclusive with <code>key</code>.</p>",
                             "markdownDescription": "Prefix for all keys in this collection. It's used when a collection contains multiple files. This attribute is\nmutually exclusive with `key`."
                         },
                         "key": {
                             "type": "string",
+                            "minLength": 1,
                             "description": "Exact key for a single file in the collection. This is used when a collection contains only one specific file. This attribute is mutually exclusive with keyPrefix.",
                             "x-intellij-html-description": "<p>Exact key for a single file in the collection. This is used when a collection contains only one specific file.\nThis attribute is mutually exclusive with <code>keyPrefix</code>.</p>",
                             "markdownDescription": "Exact key for a single file in the collection. This is used when a collection contains only one specific file.\nThis attribute is mutually exclusive with `keyPrefix`."

--- a/packages/json_schemas/schemas/key_value_store.schema.json
+++ b/packages/json_schemas/schemas/key_value_store.schema.json
@@ -39,10 +39,12 @@
                             "uniqueItems": true
                         },
                         "keyPrefix": {
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "key": {
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "jsonSchema": {
                             "$ref": "http://json-schema.org/draft-07/schema#"

--- a/test/key_value_store_schema.test.ts
+++ b/test/key_value_store_schema.test.ts
@@ -167,6 +167,52 @@ describe('key_value_store.json', () => {
             );
         });
 
+        it('should not validate when keyPrefix is an empty string', () => {
+            const schema = {
+                actorKeyValueStoreSchemaVersion: 1,
+                title: 'My Key-Value Store',
+                collections: {
+                    myCollection: {
+                        title: 'My Collection',
+                        keyPrefix: '', // empty string is invalid
+                        contentTypes: ['application/json'],
+                    },
+                },
+            };
+
+            const isValid = validator(schema);
+            expect(isValid).toBe(false);
+            expect(validator.errors).toContainEqual(
+                expect.objectContaining({
+                    keyword: 'minLength',
+                    instancePath: '/collections/myCollection/keyPrefix',
+                }),
+            );
+        });
+
+        it('should not validate when key is an empty string', () => {
+            const schema = {
+                actorKeyValueStoreSchemaVersion: 1,
+                title: 'My Key-Value Store',
+                collections: {
+                    myCollection: {
+                        title: 'My Collection',
+                        key: '', // empty string is invalid
+                        contentTypes: ['application/json'],
+                    },
+                },
+            };
+
+            const isValid = validator(schema);
+            expect(isValid).toBe(false);
+            expect(validator.errors).toContainEqual(
+                expect.objectContaining({
+                    keyword: 'minLength',
+                    instancePath: '/collections/myCollection/key',
+                }),
+            );
+        });
+
         it('should not validate with empty contentTypes array', () => {
             const schema = {
                 actorKeyValueStoreSchemaVersion: 1,


### PR DESCRIPTION
### What

Add `minLength: 1` to `key` and `keyPrefix` in the key-value store collection schema, so an empty string is no longer a valid value.
The `collection` needs to have a non-empty key/key prefix.

### Specific changes

- `key_value_store.schema.json`: `minLength: 1` on `key` and `keyPrefix`.
- Tests: empty `key` / empty `keyPrefix` now rejected with a `minLength` error.

Related to https://github.com/apify/apify-core/issues/28502