### PR TITLE
fix: correct outdated JSDoc type annotations in utilities and input_secrets

### DIFF
--- a/packages/input_secrets/src/input_secrets.ts
+++ b/packages/input_secrets/src/input_secrets.ts
@@ -166,9 +166,8 @@ export function encryptInputSecrets<T extends Record<string, any>>({
 
 /**
  * Decrypts actor input secrets
- * @param {Object} input
- * @param {KeyObject} privateKey
- * @returns Object
+ * @param input - actor input object that may contain encrypted secret values
+ * @param privateKey - private key used to decrypt the secret values
  */
 export function decryptInputSecrets<T>({ input, privateKey }: { input: T; privateKey: KeyObject }): T {
     ow(input, ow.object);

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -41,8 +41,7 @@ export function deterministicUniqueId(key: string, length = 17): string {
 
 /**
  * Returns a random integer between 0 and max (excluded, unless it is also 0).
- * @param {number} maxExcluded
- * @returns {number}
+ * @param maxExcluded - exclusive upper bound; the returned value is always lower than this
  */
 export function getRandomInt(maxExcluded: number) {
     maxExcluded = Math.floor(maxExcluded);
@@ -63,7 +62,7 @@ export function parseDateFromJson(date: string | Date) {
 
 /**
  * Returns a Promise object that will wait a specific number of milliseconds.
- * @param {number} millis Time to wait. If the value is not larger than zero, the promise resolves immediately.
+ * @param millis - time to wait in milliseconds; if not larger than zero, the promise resolves immediately
  */
 export async function delayPromise(millis: number): Promise<void> {
     return new Promise((resolve) => {


### PR DESCRIPTION
## TL;DR

A failed npm publish on **2026-06-09** left three packages **tagged in git but absent from npm**, and the **2026-06-12** release then published `@apify/input_schema@3.28.15` with a dependency on one of them. The result: **`npm install -g apify-cli` is broken globally** right now (and so is every CI that installs it — e.g. `apify/actor-templates`).

This PR forces a fresh **patch release** of the drifted packages to reconcile npm with git. The doc edits are real (removing redundant TS JSDoc type tags); their job here is to give Lerna a change to release.

## What's broken

```
@apify/input_schema@3.28.15 (on npm)  →  @apify/input_secrets@^1.2.44  ❌ never published (npm has 1.2.43)
@apify/input_secrets@1.2.44           →  @apify/utilities@^2.33.0      ❌ never published (npm has 2.32.2)
@apify/markdown@3.0.68                                                 ❌ never published (npm has 3.0.67)
```

Reproduce (clean machine, outside any repo):
```bash
cd "$(mktemp -d)" && npm init -y >/dev/null
npm install @apify/input_schema@3.28.15
# -> npm error code ETARGET: No matching version found for @apify/input_secrets@^1.2.44
```

## Why it happened

The repo uses **Lerna independent + pnpm `workspace:^`**. Lerna's release is two-phase: it commits version bumps and **creates git tags first**, then publishes to npm package-by-package. The 06-09 publish run **failed mid-flight** on a Sigstore/npm **provenance transparency-log error**:

```
@apify/utilities: TLOG_CREATE_ENTRY_ERROR — (409) an equivalent entry already exists in the transparency log
```

Rekor lookup of that entry shows it was integrated at **2026-06-09T11:28:37Z**, ~70s *into* the run — i.e. the run **successfully wrote the Rekor entry, then retried the identical submission and collided with its own write** (lost-ack double-submit). Lerna aborted (compounded by its `errno "undefined" is not a valid exit code` bug), so `utilities@2.33.0`, `input_secrets@1.2.44`, and `markdown@3.0.68` never finished publishing — but their git tags were already committed. On 06-12, `input_schema` was released and `workspace:^` baked the in-repo `^1.2.44` into its published manifest, exposing the gap as `latest`.

Re-running the pipeline can't fix it: `lerna changed` sees the existing tags → 0 changes → no-op. And `lerna publish from-package` would re-attempt the *same* versions, whose digests are **permanently** poisoned by the immutable Rekor 409. **Only fresh versions escape it.**

## What this PR does

`fix:` commits to **`utilities`** and **`input_secrets`** (the broken chain). On merge, Lerna bumps them and **cascades to their dependents**:

| package | bump | why |
|---|---|---|
| `@apify/utilities` | 2.33.0 → **2.33.1** | direct `fix:` (root of the chain) |
| `@apify/input_secrets` | 1.2.44 → **1.2.45** | direct `fix:` |
| `@apify/markdown` | 3.0.68 → **3.0.69** | dependent of utilities (cascade) |
| `@apify/input_schema` | 3.28.15 → **3.28.16** | dependent of input_secrets (cascade) |

All four get **new versions → new tarball digests → new Rekor entries → no 409**, and every `workspace:^` range resolves to a version published in the same run. `input_schema@3.28.15`'s `^1.2.44` is satisfied by the new `1.2.45`, so the already-published version becomes installable again too — `apify-cli` unblocked.

## Verify after merge/publish
```bash
for s in input_secrets@1.2.45 utilities@2.33.1 markdown@3.0.69 input_schema@3.28.16; do npm view @apify/$s version; done
cd "$(mktemp -d)" && npm init -y >/dev/null && npm install @apify/input_schema@3.28.15   # resolves now
```

## Follow-ups (not in this PR) — tracked in #649
- **Add a post-publish verification step** to `publish_to_npm.yaml`: after `lerna publish`, assert each package's current version resolves on npm (`npm view <pkg>@<ver>`), so git/npm drift fails the build immediately instead of surfacing days later.
- **Handle the Rekor 409 gracefully** (upgrade npm / treat "entry already exists" as success) so a lost-ack retry doesn't abort a whole multi-package release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
