### PR TITLE
feat: add forbidden usernames for open-source roles

### DIFF
--- a/packages/utilities/src/usernames.ts
+++ b/packages/utilities/src/usernames.ts
@@ -382,6 +382,8 @@ const FORBIDDEN_USERNAMES_REGEXPS = [
     'core-team',
     'oss',
     'open-source',
+    'opensource',
+    'open-source-software',
 
     // Anti-abuse / scam-bait names (frequently used in account fraud)
     'spam',

--- a/test/usernames.test.ts
+++ b/test/usernames.test.ts
@@ -64,6 +64,12 @@ describe('isForbiddenUsername()', () => {
         expect(isForbiddenUsername('dataset')).toBe(true);
         expect(isForbiddenUsername('datasets')).toBe(true);
 
+        // Open-source / community roles
+        expect(isForbiddenUsername('oss')).toBe(true);
+        expect(isForbiddenUsername('open-source')).toBe(true);
+        expect(isForbiddenUsername('opensource')).toBe(true);
+        expect(isForbiddenUsername('open-source-software')).toBe(true);
+
         // Organizations / workspaces / permissions
         expect(isForbiddenUsername('org')).toBe(true);
         expect(isForbiddenUsername('organisation')).toBe(true);


### PR DESCRIPTION
Expands the forbidden usernames list to include additional variations of open-source and community role identifiers.

- Added `opensource`, `open-source-software` to forbidden usernames alongside existing `oss` and `open-source`
- Updated test cases to verify all four variations are properly rejected

This prevents users from claiming usernames associated with open-source initiatives and community roles.

https://claude.ai/code/session_01BTjzdKB3gJQ4PoKPp18qvk