### PR TITLE
chore(ci): Revert previous version bump, bump `apify/signed-commit` action

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -89,7 +89,7 @@ jobs:
 
             - name: Commit and push changes
               id: signed_commit
-              uses: apify/actions/signed-commit@v1.2.0
+              uses: apify/actions/signed-commit@v1.4.0
               with:
                   message: 'chore: release new package versions [skip ci]'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See the changelogs of each package:
 
 package | version | changelog
 --------|---------|----------
-`@apify/actor-memory-expression` | 0.2.0 | [CHANGELOG](./packages/actor-memory-expression/CHANGELOG.md)
+`@apify/actor-memory-expression` | 0.1.18 | [CHANGELOG](./packages/actor-memory-expression/CHANGELOG.md)
 `@apify/consts` | 2.53.3 | [CHANGELOG](./packages/consts/CHANGELOG.md)
 `@apify/datastructures` | 2.0.6 | [CHANGELOG](./packages/datastructures/CHANGELOG.md)
 `@apify/git` | 2.1.6 | [CHANGELOG](./packages/git/CHANGELOG.md)

--- a/packages/actor-memory-expression/CHANGELOG.md
+++ b/packages/actor-memory-expression/CHANGELOG.md
@@ -3,23 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.2.0](https://github.com/apify/apify-shared-js/compare/@apify/actor-memory-expression@0.1.18...@apify/actor-memory-expression@0.2.0) (2026-07-03)
-
-
-### Bug Fixes
-
-* **ci:** Add GH_TOKEN env variable to workflow using the GitHub CLI, revert previous version bump ([#663](https://github.com/apify/apify-shared-js/issues/663)) ([f4315ba](https://github.com/apify/apify-shared-js/commit/f4315ba6bec17fa1a54eaa49a93c89d1500a7ad9))
-* **ci:** Use long commit SHA when creating git tags during new release, revert previous version bump ([#664](https://github.com/apify/apify-shared-js/issues/664)) ([effe553](https://github.com/apify/apify-shared-js/commit/effe553d042cccc26c99b83e2ac15ade1531b865))
-
-
-### Features
-
-* memory expression allow comparing text ([#661](https://github.com/apify/apify-shared-js/issues/661)) ([7cb3fbf](https://github.com/apify/apify-shared-js/commit/7cb3fbffcdb2eb62de47f7d64cbe95f738a81ebb)), closes [#660](https://github.com/apify/apify-shared-js/issues/660)
-
-
-
-
-
 ## [0.1.18](https://github.com/apify/apify-shared-js/compare/@apify/actor-memory-expression@0.1.17...@apify/actor-memory-expression@0.1.18) (2026-06-03)
 
 **Note:** Version bump only for package @apify/actor-memory-expression

--- a/packages/actor-memory-expression/package.json
+++ b/packages/actor-memory-expression/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apify/actor-memory-expression",
-    "version": "0.2.0",
+    "version": "0.1.18",
     "description": "Utility to evaluate dynamic memory expressions for Apify actors.",
     "main": "./dist/cjs/index.cjs",
     "module": "./dist/esm/index.mjs",


### PR DESCRIPTION
This reverts commit 975c51d, and bumps `apify/signed-commit` action to fix NPM publication workflow.