### PR TITLE
feat(utilities): add validateKvsKey with named illegal-character diagnostics

### DIFF
--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -12,3 +12,4 @@ export * from './code_hash_manager';
 export * from './hmac';
 export * from './storages';
 export * from './parse_boolean';
+export * from './kvs_key_validator';

--- a/packages/utilities/src/kvs_key_validator.ts
+++ b/packages/utilities/src/kvs_key_validator.ts
@@ -1,0 +1,155 @@
+import { KEY_VALUE_STORE_KEY_REGEX } from '@apify/consts';
+
+/**
+ * Max allowed length of a key-value store record key. Kept in sync with the
+ * `{1,256}` quantifier on {@link KEY_VALUE_STORE_KEY_REGEX} in `@apify/consts`.
+ */
+export const KEY_VALUE_STORE_KEY_MAX_LENGTH = 256;
+
+/**
+ * Regex matching a single character that is allowed in a key-value store
+ * record key (the character class from {@link KEY_VALUE_STORE_KEY_REGEX},
+ * without the length quantifier). Used to compute the set of illegal
+ * characters in a rejected key.
+ */
+const KEY_VALUE_STORE_KEY_ALLOWED_CHAR_REGEX = /[a-zA-Z0-9!\-_.'()]/;
+
+/**
+ * Human-readable name for a small set of characters that render ambiguously
+ * (e.g. as invisible whitespace) in error messages. Improves the readability
+ * of the "illegal character(s):" list.
+ */
+const CHARACTER_NAMES: Record<string, string> = {
+    ' ': 'space',
+    '\t': 'tab',
+    '\n': 'newline',
+    '\r': 'carriage return',
+    '\v': 'vertical tab',
+    '\f': 'form feed',
+    '\0': 'null',
+};
+
+function describeCharacter(char: string): string {
+    const named = CHARACTER_NAMES[char];
+    if (named) return `${JSON.stringify(char)} (${named})`;
+
+    // Common punctuation gets a friendly name so error messages read well.
+    const punctuationNames: Record<string, string> = {
+        ':': 'colon',
+        ';': 'semicolon',
+        '/': 'slash',
+        '\\': 'backslash',
+        '@': 'at-sign',
+        '#': 'hash',
+        $: 'dollar sign',
+        '%': 'percent',
+        '^': 'caret',
+        '&': 'ampersand',
+        '*': 'asterisk',
+        '+': 'plus',
+        '=': 'equals',
+        '?': 'question mark',
+        '<': 'less-than',
+        '>': 'greater-than',
+        '{': 'left curly brace',
+        '}': 'right curly brace',
+        '[': 'left square bracket',
+        ']': 'right square bracket',
+        '|': 'pipe',
+        '~': '~ (tilde)',
+        '`': 'backtick',
+        '"': 'double quote',
+        ',': 'comma',
+    };
+    const punctName = punctuationNames[char];
+    if (punctName) return `${JSON.stringify(char)} (${punctName})`;
+
+    // Control characters and other non-printables: show the U+xxxx codepoint.
+    const codepoint = char.codePointAt(0);
+    if (codepoint !== undefined && (codepoint < 0x20 || codepoint === 0x7f)) {
+        return `U+${codepoint.toString(16).toUpperCase().padStart(4, '0')}`;
+    }
+
+    return JSON.stringify(char);
+}
+
+/**
+ * Result of {@link validateKvsKey}. `valid: true` means the key is accepted by
+ * {@link KEY_VALUE_STORE_KEY_REGEX}; otherwise the object describes each
+ * distinct problem so callers can build a helpful error message.
+ */
+export type KvsKeyValidationResult =
+    | { valid: true }
+    | {
+          valid: false;
+          /** Distinct illegal characters, in order of first appearance in the key. Empty when only length is wrong. */
+          illegalCharacters: string[];
+          /** True when `key.length` exceeds {@link KEY_VALUE_STORE_KEY_MAX_LENGTH}. */
+          tooLong: boolean;
+          /** True when `key` is empty. */
+          empty: boolean;
+          /** Human-readable message combining all problems, ready to include in an error. */
+          message: string;
+      };
+
+/**
+ * Validate a key-value store record key against {@link KEY_VALUE_STORE_KEY_REGEX}.
+ *
+ * On failure, callers get back the exact list of illegal characters plus the
+ * length check, so the resulting error message can point at the actual problem
+ * (e.g. `illegal character(s): ":" (colon)`) instead of restating the whole
+ * allowed charset.
+ */
+export function validateKvsKey(key: string): KvsKeyValidationResult {
+    if (KEY_VALUE_STORE_KEY_REGEX.test(key)) {
+        return { valid: true };
+    }
+
+    const empty = key.length === 0;
+    const tooLong = key.length > KEY_VALUE_STORE_KEY_MAX_LENGTH;
+
+    // Compute the set of illegal characters in order of first appearance.
+    const seen = new Set<string>();
+    const illegalCharacters: string[] = [];
+    for (const char of key) {
+        if (!KEY_VALUE_STORE_KEY_ALLOWED_CHAR_REGEX.test(char) && !seen.has(char)) {
+            seen.add(char);
+            illegalCharacters.push(char);
+        }
+    }
+
+    const problems: string[] = [];
+    if (empty) {
+        problems.push('key is empty');
+    }
+    if (tooLong) {
+        problems.push(`length ${key.length} > ${KEY_VALUE_STORE_KEY_MAX_LENGTH}`);
+    }
+    if (illegalCharacters.length > 0) {
+        const rendered = illegalCharacters.map(describeCharacter).join(', ');
+        problems.push(`illegal character(s): ${rendered}`);
+    }
+
+    const message =
+        `Key-value store record key is invalid (${problems.join('; ')}). ` +
+        `Allowed characters are a-zA-Z0-9 and !-_.'(), max length ${KEY_VALUE_STORE_KEY_MAX_LENGTH}.`;
+
+    return {
+        valid: false,
+        illegalCharacters,
+        tooLong,
+        empty,
+        message,
+    };
+}
+
+/**
+ * Throws a `TypeError` with a helpful message (see {@link validateKvsKey}) if
+ * `key` is not a valid key-value store record key. Otherwise returns silently.
+ */
+export function assertValidKvsKey(key: string): void {
+    const result = validateKvsKey(key);
+    if (!result.valid) {
+        throw new TypeError(result.message);
+    }
+}

--- a/test/kvs_key_validator.test.ts
+++ b/test/kvs_key_validator.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertValidKvsKey, KEY_VALUE_STORE_KEY_MAX_LENGTH, validateKvsKey } from '@apify/utilities';
+
+describe('validateKvsKey()', () => {
+    it('accepts keys made of the allowed character set', () => {
+        for (const key of ['foo', 'INPUT', 'file.json', 'abc-123_XYZ.tar.gz', "it's-fine", 'a', '0']) {
+            expect(validateKvsKey(key)).toEqual({ valid: true });
+        }
+    });
+
+    it('accepts a key at the maximum length', () => {
+        const key = 'a'.repeat(KEY_VALUE_STORE_KEY_MAX_LENGTH);
+        expect(validateKvsKey(key)).toEqual({ valid: true });
+    });
+
+    it('rejects an empty key with a dedicated flag', () => {
+        const result = validateKvsKey('');
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.empty).toBe(true);
+        expect(result.tooLong).toBe(false);
+        expect(result.illegalCharacters).toEqual([]);
+        expect(result.message).toContain('key is empty');
+    });
+
+    it('names the single illegal character in the failure message', () => {
+        const result = validateKvsKey('price:yamaha-ysp-5600');
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.illegalCharacters).toEqual([':']);
+        expect(result.tooLong).toBe(false);
+        expect(result.message).toContain('illegal character(s): ":" (colon)');
+        // Should NOT falsely blame length.
+        expect(result.message).not.toMatch(/length \d+ >/);
+    });
+
+    it('deduplicates illegal characters and preserves first-seen order', () => {
+        const result = validateKvsKey('a:b/c:d/e');
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.illegalCharacters).toEqual([':', '/']);
+        expect(result.message).toMatch(/illegal character\(s\): ":" \(colon\), "\/" \(slash\)/);
+    });
+
+    it('reports both an illegal character AND excess length when both are wrong', () => {
+        const key = `${'a'.repeat(KEY_VALUE_STORE_KEY_MAX_LENGTH)}::`;
+        const result = validateKvsKey(key);
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.tooLong).toBe(true);
+        expect(result.illegalCharacters).toEqual([':']);
+        expect(result.message).toContain(`length ${key.length} > ${KEY_VALUE_STORE_KEY_MAX_LENGTH}`);
+        expect(result.message).toContain('illegal character(s): ":" (colon)');
+    });
+
+    it('reports length only when charset is fine but length exceeds the max', () => {
+        const key = 'a'.repeat(KEY_VALUE_STORE_KEY_MAX_LENGTH + 1);
+        const result = validateKvsKey(key);
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.tooLong).toBe(true);
+        expect(result.illegalCharacters).toEqual([]);
+        expect(result.message).toContain(`length ${key.length} > ${KEY_VALUE_STORE_KEY_MAX_LENGTH}`);
+        expect(result.message).not.toContain('illegal character');
+    });
+
+    it('gives readable names to whitespace and control characters', () => {
+        const result = validateKvsKey('a b\tc\n');
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.illegalCharacters).toEqual([' ', '\t', '\n']);
+        expect(result.message).toContain('(space)');
+        expect(result.message).toContain('(tab)');
+        expect(result.message).toContain('(newline)');
+    });
+});
+
+describe('assertValidKvsKey()', () => {
+    it('returns silently for a valid key', () => {
+        expect(() => assertValidKvsKey('valid_key.json')).not.toThrow();
+    });
+
+    it('throws TypeError naming the illegal character', () => {
+        expect(() => assertValidKvsKey('price:foo')).toThrow(TypeError);
+        expect(() => assertValidKvsKey('price:foo')).toThrow(/illegal character\(s\): ":" \(colon\)/);
+    });
+});


### PR DESCRIPTION
## Summary

Add `validateKvsKey` and `assertValidKvsKey` in `@apify/utilities` so callers that reject key-value store record keys can produce an error message that names the actual problem instead of restating the entire allowed charset plus the length limit.

## Motivation

The current pattern for validating a KVS record key is to test it against `KEY_VALUE_STORE_KEY_REGEX` in `@apify/consts` and, on failure, throw a message like:

> The `"key"` argument `"price:yamaha-ysp-5600-<...>"` must be at most 256 characters long and only contain the following characters: `a-zA-Z0-9!-_.'()`

That message conflates two independent checks (charset AND length) and forces the caller of the API to diff their key against the allowed set by hand. In the example above, the length is fine and the only problem is a single colon — but the user has to figure that out themselves. This is especially painful when the key contains an invisible character (a stray tab, a trailing newline, a non-breaking space).

## What this change adds

`validateKvsKey(key)` returns a discriminated union:

- On success: `{ valid: true }`.
- On failure: `{ valid: false, illegalCharacters, tooLong, empty, message }` where
  - `illegalCharacters` is the deduplicated list of characters not in `a-zA-Z0-9!-_.'()`, in order of first appearance;
  - `tooLong` is `true` when `key.length > 256`;
  - `empty` is `true` when the key is the empty string;
  - `message` is a ready-to-use human-readable string, e.g.
    ```
    Key-value store record key is invalid (illegal character(s): ":" (colon)). Allowed characters are a-zA-Z0-9 and !-_.'(), max length 256.
    ```

Length and charset are reported independently: a key that both contains a bad character AND exceeds 256 chars now gets both diagnostics; a key with only a bad character no longer falsely blames length.

Whitespace and control characters get a friendly name (`(space)`, `(tab)`, `(newline)`, `U+0007` …) so the failure is unambiguous even when the offending char is invisible in a terminal.

`assertValidKvsKey(key)` is a thin throwing wrapper for callers that just want to guard.

## Test plan

`test/kvs_key_validator.test.ts` covers:

- [x] Valid keys (including `it's-fine`, `INPUT`, `file.json`, `a`, `0`, and a key at exactly 256 chars).
- [x] Empty key → `empty: true`, no length/charset noise.
- [x] Key with a single illegal char (`price:yamaha-ysp-5600`) → `illegalCharacters: [':']`, message contains `illegal character(s): ":" (colon)`, message does NOT match `/length \d+ >/`.
- [x] Duplicate + multiple illegal chars → deduplicated in first-seen order.
- [x] Length-only failure → `illegalCharacters: []`, message contains `length 257 > 256`, no charset noise.
- [x] Length + charset failure → both problems reported.
- [x] Whitespace chars get named (`(space)`, `(tab)`, `(newline)`).
- [x] `assertValidKvsKey` throws `TypeError` with the composed message.

Ran locally:

```
$ pnpm vitest run test/kvs_key_validator.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ pnpm --filter @apify/utilities run build
DTS Build success

$ pnpm lint
Found 0 warnings and 0 errors.
```

## Follow-ups (not in this PR)

Consumers that currently reject KVS keys by hand-rolling their own error message (notably the storage error in the Apify core API) can be migrated to `validateKvsKey` in a separate change — this PR only adds the utility and its tests.

---

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._