### PR TITLE
feat(timeout): add `extendTimeout` to push back a running deadline

### DIFF
--- a/packages/timeout/src/index.ts
+++ b/packages/timeout/src/index.ts
@@ -5,6 +5,18 @@ export interface AbortContext {
 }
 
 /**
+ * A single `addTimeoutToPromise` call. Nested calls share the `cancelTask` controller of the
+ * enclosing frame (so `tryCancel()` behaves the same at any depth), but each call gets its own
+ * frame, which is what lets {@apilink extendTimeout} tell the layers apart.
+ */
+interface TimeoutFrame extends AbortContext {
+    /** The enclosing frame, when this call is nested inside another `addTimeoutToPromise`. */
+    parent?: TimeoutFrame;
+    /** Pushes this frame's deadline back. Becomes a no-op once the frame times out or settles. */
+    extend?: (extraMillis: number) => void;
+}
+
+/**
  * `AsyncLocalStorage` instance that is used for baring the AbortContext inside user provided handler.
  * We can use it to access the `AbortContext` instance via `storage.getStore()`, and there we can access
  * `cancelTask` instance of `AbortController`.
@@ -65,10 +77,14 @@ export async function addTimeoutToPromise<T>(
     timeoutMillis: number,
     errorMessage: string | Error,
 ): Promise<T> {
-    // respect existing context to support nesting
-    const context = storage.getStore() ?? {
-        cancelTask: new AbortController(),
-    };
+    // respect existing context to support nesting - every call needs a store of its own for
+    // `extendTimeout` to be able to tell the layers apart, but we keep prototypally inheriting from
+    // the enclosing one, so that reads of anything stashed on an outer context still resolve
+    const parent = storage.getStore() as TimeoutFrame | undefined;
+    const context: TimeoutFrame = Object.create(parent ?? Object.prototype);
+    // shared with the enclosing frame, so cancellation still propagates across the whole chain at once
+    context.cancelTask = parent?.cancelTask ?? new AbortController();
+    context.parent = parent;
     let returnValue: T;
 
     // calls handler, skips internal `TimeoutError`s that might have been thrown
@@ -84,17 +100,87 @@ export async function addTimeoutToPromise<T>(
     };
 
     return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
+        let deadline = Date.now() + timeoutMillis;
+        let settled = false;
+
+        const fire = () => {
+            settled = true;
             context.cancelTask.abort();
             const error = errorMessage instanceof Error ? errorMessage : new TimeoutError(errorMessage);
             reject(error);
-        }, timeoutMillis);
+        };
+
+        // the callback is kept anonymous on purpose - a named one would show up in the stack trace of
+        // the `TimeoutError` instead of the `Timeout._onTimeout` frame consumers match against
+        let timeout = setTimeout(() => fire(), timeoutMillis);
+
+        // the `settled` guard matters for handlers that keep running after they timed out (i.e. those
+        // that don't call `tryCancel()`) - without it they could schedule a timer that never fires
+        // anything useful, but still keeps the event loop alive
+        context.extend = (extraMillis: number) => {
+            if (settled) {
+                return;
+            }
+
+            clearTimeout(timeout);
+            deadline += extraMillis;
+            timeout = setTimeout(() => fire(), Math.max(deadline - Date.now(), 0));
+        };
 
         storage.run(context, () => {
             wrap()
                 .then(() => resolve(returnValue))
                 .catch(reject)
-                .finally(() => clearTimeout(timeout));
+                .finally(() => {
+                    settled = true;
+                    clearTimeout(timeout);
+                });
         });
     });
+}
+
+export interface ExtendTimeoutOptions {
+    /**
+     * Whether to extend the enclosing timeouts by the same amount as well. Keep this enabled (the
+     * default) unless an enclosing timeout is meant to be a hard limit on the total time - with it
+     * disabled, a nested handler can be killed by an outer timeout right after extending its own.
+     * @default true
+     */
+    propagate?: boolean;
+}
+
+/**
+ * Pushes the deadline of the currently running timeout back by `extraMillis`, for cases where the
+ * required time is only known once the handler is already running. Call it from inside a handler
+ * wrapped in {@apilink addTimeoutToPromise}; outside of one it is a no-op.
+ *
+ * ```ts
+ * await addTimeoutToPromise(async () => {
+ *     const pageCount = await countPages();
+ *     tryCancel();
+ *     // we only now know this page is a big one, so ask for 10 more seconds per page
+ *     extendTimeout(pageCount * 10_000);
+ *     await scrapeAllPages();
+ * }, 30_000, 'Handler timed out!');
+ * ```
+ *
+ * Enclosing timeouts are extended by the same amount by default, so that a nested handler asking for
+ * more time is not killed moments later by an outer timeout it cannot see. Pass `propagate: false` to
+ * extend only the innermost timeout, leaving any enclosing ones as a hard limit on the total time.
+ *
+ * Extending an already timed out (or already finished) handler does nothing.
+ */
+export function extendTimeout(extraMillis: number, options: ExtendTimeoutOptions = {}): void {
+    const { propagate = true } = options;
+    let frame = storage.getStore() as TimeoutFrame | undefined;
+
+    while (frame) {
+        frame.extend?.(extraMillis);
+
+        if (!propagate) {
+            return;
+        }
+
+        frame = frame.parent;
+    }
 }

--- a/packages/timeout/src/index.ts
+++ b/packages/timeout/src/index.ts
@@ -12,7 +12,7 @@ export interface AbortContext {
 interface TimeoutFrame extends AbortContext {
     /** The enclosing frame, when this call is nested inside another `addTimeoutToPromise`. */
     parent?: TimeoutFrame;
-    /** Pushes this frame's deadline back. Returns `false` once the frame timed out or settled. */
+    /** Pushes this frame's deadline ahead. Returns `false` if the frame has already timed out or settled. */
     extend?: (extraMillis: number) => boolean;
 }
 

--- a/packages/timeout/src/index.ts
+++ b/packages/timeout/src/index.ts
@@ -7,13 +7,13 @@ export interface AbortContext {
 /**
  * A single `addTimeoutToPromise` call. Nested calls share the `cancelTask` controller of the
  * enclosing frame (so `tryCancel()` behaves the same at any depth), but each call gets its own
- * frame, which is what lets {@apilink extendTimeout} tell the layers apart.
+ * frame, which is what lets {@link extendTimeout} tell the layers apart.
  */
 interface TimeoutFrame extends AbortContext {
     /** The enclosing frame, when this call is nested inside another `addTimeoutToPromise`. */
     parent?: TimeoutFrame;
-    /** Pushes this frame's deadline back. Becomes a no-op once the frame times out or settles. */
-    extend?: (extraMillis: number) => void;
+    /** Pushes this frame's deadline back. Returns `false` once the frame timed out or settled. */
+    extend?: (extraMillis: number) => boolean;
 }
 
 /**
@@ -119,12 +119,14 @@ export async function addTimeoutToPromise<T>(
         // anything useful, but still keeps the event loop alive
         context.extend = (extraMillis: number) => {
             if (settled) {
-                return;
+                return false;
             }
 
             clearTimeout(timeout);
             deadline += extraMillis;
             timeout = setTimeout(() => fire(), Math.max(deadline - Date.now(), 0));
+
+            return true;
         };
 
         storage.run(context, () => {
@@ -152,7 +154,7 @@ export interface ExtendTimeoutOptions {
 /**
  * Pushes the deadline of the currently running timeout back by `extraMillis`, for cases where the
  * required time is only known once the handler is already running. Call it from inside a handler
- * wrapped in {@apilink addTimeoutToPromise}; outside of one it is a no-op.
+ * wrapped in {@link addTimeoutToPromise}; outside of one it is a no-op.
  *
  * ```ts
  * await addTimeoutToPromise(async () => {
@@ -175,7 +177,11 @@ export function extendTimeout(extraMillis: number, options: ExtendTimeoutOptions
     let frame = storage.getStore() as TimeoutFrame | undefined;
 
     while (frame) {
-        frame.extend?.(extraMillis);
+        // a frame that already timed out means the caller is running past its deadline - it must not
+        // push back the enclosing ones either, those are what still bounds it
+        if (frame.extend?.(extraMillis) === false) {
+            return;
+        }
 
         if (!propagate) {
             return;

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -2,7 +2,8 @@ import { setTimeout } from 'node:timers/promises';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
+import type { ExtendTimeoutOptions } from '@apify/timeout';
+import { addTimeoutToPromise, extendTimeout, storage, tryCancel } from '@apify/timeout';
 
 describe('timeout with abort controller', () => {
     let position = 0;
@@ -48,6 +49,14 @@ describe('timeout with abort controller', () => {
         expect(position).toBe(3);
     });
 
+    it('reports the timer frame in the stack trace', async () => {
+        // consumers (crawlee) match on this frame when logging timeout errors, so it must not be
+        // replaced by the name of whatever function we happen to hand over to `setTimeout`
+        const err = await addTimeoutToPromise(async () => handler(), 50, 'timed out').catch((e: Error) => e);
+
+        expect(err.stack).toMatch(/at Timeout\._onTimeout/);
+    });
+
     it('timeouts with nesting', async () => {
         // this will timeout and cause failure, but it will happen sooner than in 200ms, so err 1 will be thrown
         async function handler2() {
@@ -56,5 +65,97 @@ describe('timeout with abort controller', () => {
 
         await expect(addTimeoutToPromise(async () => handler2(), 200, 'err 2')).rejects.toThrow('err 1');
         expect(position).toBe(3);
+    });
+});
+
+describe('extendTimeout', () => {
+    // needs 160ms in total, so it only finishes if the timeout gets extended
+    async function slowHandler(extraMillis: number, options?: ExtendTimeoutOptions) {
+        await setTimeout(60);
+        tryCancel();
+        extendTimeout(extraMillis, options);
+        await setTimeout(100);
+        tryCancel();
+
+        return 123;
+    }
+
+    it('extends a running timeout', async () => {
+        const res = await addTimeoutToPromise(async () => slowHandler(200), 100, 'timed out');
+        expect(res).toBe(123);
+    });
+
+    it('still times out when the extension is not enough', async () => {
+        await expect(addTimeoutToPromise(async () => slowHandler(20), 100, 'timed out')).rejects.toThrow('timed out');
+    });
+
+    it('extends the enclosing timeouts too', async () => {
+        // the outer 150ms would kill the extended inner handler (160ms) if it was not extended as well
+        const res = await addTimeoutToPromise(
+            async () => addTimeoutToPromise(async () => slowHandler(200), 100, 'inner timed out'),
+            150,
+            'outer timed out',
+        );
+        expect(res).toBe(123);
+    });
+
+    it('leaves the enclosing timeouts alone with `propagate: false`', async () => {
+        // the inner handler extends itself to 300ms, but the outer 150ms stays a hard limit
+        await expect(
+            addTimeoutToPromise(
+                async () =>
+                    addTimeoutToPromise(async () => slowHandler(200, { propagate: false }), 100, 'inner timed out'),
+                150,
+                'outer timed out',
+            ),
+        ).rejects.toThrow('outer timed out');
+    });
+
+    it('is a no-op outside of a timeout handler', () => {
+        expect(() => extendTimeout(100)).not.toThrow();
+    });
+
+    it('keeps the enclosing context readable from a nested one', async () => {
+        // nested calls used to share a single store object, so anything put on the context of an outer
+        // handler was readable from an inner one - each call has its own store now, and this makes sure
+        // it still inherits from the enclosing one
+        await addTimeoutToPromise(
+            async () => {
+                (storage.getStore() as Record<string, unknown>).marker = 'from-outer';
+
+                await addTimeoutToPromise(
+                    async () => {
+                        expect((storage.getStore() as Record<string, unknown>).marker).toBe('from-outer');
+                    },
+                    100,
+                    'inner timed out',
+                );
+            },
+            200,
+            'outer timed out',
+        );
+    });
+
+    it('is ignored once the handler timed out', async () => {
+        let extended = false;
+
+        // no `tryCancel()`, so the handler keeps running after it timed out
+        const promise = addTimeoutToPromise(
+            async () => {
+                await setTimeout(60);
+                extendTimeout(1000);
+                extended = true;
+
+                return 123;
+            },
+            30,
+            'timed out',
+        );
+
+        await expect(promise).rejects.toThrow('timed out');
+
+        // the extension must not resurrect the timer or turn the rejection into a resolution
+        await setTimeout(60);
+        expect(extended).toBe(true);
     });
 });

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -116,9 +116,7 @@ describe('extendTimeout', () => {
     });
 
     it('keeps the enclosing context readable from a nested one', async () => {
-        // nested calls used to share a single store object, so anything put on the context of an outer
-        // handler was readable from an inner one - each call has its own store now, and this makes sure
-        // it still inherits from the enclosing one
+        // each call has a store of its own, but it must still inherit from the enclosing one
         await addTimeoutToPromise(
             async () => {
                 (storage.getStore() as Record<string, unknown>).marker = 'from-outer';
@@ -157,5 +155,30 @@ describe('extendTimeout', () => {
         // the extension must not resurrect the timer or turn the rejection into a resolution
         await setTimeout(60);
         expect(extended).toBe(true);
+    });
+
+    it('does not extend the enclosing timeouts once the handler timed out', async () => {
+        // no `tryCancel()`, so the inner handler keeps running after it timed out - the extension it
+        // asks for then must not push back the outer timeout that is still bounding it
+        const promise = addTimeoutToPromise(
+            async () => {
+                await addTimeoutToPromise(
+                    async () => {
+                        await setTimeout(60);
+                        extendTimeout(5000);
+                    },
+                    30,
+                    'inner timed out',
+                ).catch(() => {});
+
+                await setTimeout(120);
+
+                return 123;
+            },
+            100,
+            'outer timed out',
+        );
+
+        await expect(promise).rejects.toThrow('outer timed out');
     });
 });


### PR DESCRIPTION
Adds `extendTimeout(extraMillis)`, for cases where the time a handler needs is only known once it is already running — e.g. a listing page that turns out to have a lot of pages to scroll through. Needed for [apify/crawlee#1485](https://github.com/apify/crawlee/issues/1485) and [apify/crawlee#2951](https://github.com/apify/crawlee/issues/2951), where a request handler needs to be able to ask for more time from the inside.

```ts
await addTimeoutToPromise(async () => {
    const pageCount = await countPages();
    tryCancel();
    extendTimeout(pageCount * 10_000);
    await scrapeAllPages();
}, 30_000, 'Handler timed out!');
```

### How

Nested calls used to share a single store object, so there was nowhere to hang a per-layer handle on — the timer was only ever reachable from the closure of the `addTimeoutToPromise` call that created it. Each call now gets a store of its own, carrying a handle to its own timer.

Two behaviours worth calling out:

- **Enclosing timeouts are extended by the same amount by default.** Otherwise a nested handler asking for more time would just be killed moments later by an outer timeout it cannot see (in crawlee's case, an internal safety net the handler author never set and cannot observe). Pass `propagate: false` to extend only the innermost one, keeping an enclosing timeout as a hard limit on the total time.
- **Extending an already timed out or finished handler is a no-op.** Cancellation is cooperative, so a handler that ignores `tryCancel()` keeps running after it timed out — without the guard it could arm a timer for an already settled promise, achieving nothing but holding the event loop open.

### Compatibility

No public API changed: `addTimeoutToPromise`, `tryCancel`, `TimeoutError` and `AbortContext` are all untouched, and `TimeoutFrame` stays internal. The `AbortController` is still inherited from the enclosing frame, so `tryCancel()` and the existing nesting semantics behave exactly as before.

The only observable difference is that `storage.getStore()` returns a different object per nesting level rather than one shared object. Since `storage` is exported, each frame prototypally inherits from the enclosing one, so reads of anything stashed on an outer context still resolve.

Verified against crawlee (aliasing the package to this branch): 676 core tests and 94 browser-pool tests pass. That run also caught a regression this branch originally had — passing a *named* function to `setTimeout` replaced the `Timeout._onTimeout` frame that crawlee matches on when logging timeout errors. Fixed, and covered by a new test here.