### PR TITLE
ci: fix tag push in publish workflow for multi-package releases

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -96,13 +96,16 @@ jobs:
 
             - name: Push tags via API to have them signed
               run: |
-                  for tag in ${{ steps.version_packages.outputs.tags }}; do
+                  while IFS= read -r tag; do
+                      [ -z "$tag" ] && continue
                       gh api -X POST /repos/${{ github.repository }}/git/refs \
                           -f ref="refs/tags/$tag" \
-                          -f sha="${{ steps.signed_commit.outputs.commit_long_sha }}"
-                  done
+                          -f sha="$COMMIT_SHA"
+                  done <<< "$TAGS"
               env:
                   GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                  TAGS: ${{ steps.version_packages.outputs.tags }}
+                  COMMIT_SHA: ${{ steps.signed_commit.outputs.commit_long_sha }}
 
             - name: Publish to NPM
               run: pnpm exec lerna publish from-package --contents dist --yes


### PR DESCRIPTION
The "Push tags via API to have them signed" step interpolated the multi-line `outputs.tags` value directly into `for tag in …; do`. As soon as a release bumps more than one package, the newline before the second tag terminates the `for … in` list and bash fails with `syntax error near unexpected token '@apify/timeout@0.4.0'` — which is exactly what broke [run 29499504721](https://github.com/apify/apify-shared-js/actions/runs/29499504721/job/87624574581).

Read the tags from an env var line-by-line (`while IFS= read -r`) instead, which handles any number of tags and avoids interpolating values into the script body.