### PR TITLE
feat: add APIFY_AI to META_ORIGINS

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -76,6 +76,7 @@ export const META_ORIGINS = {
     STANDBY: 'STANDBY', // Job started by Actor Standby
     CI: 'CI', // Job started from a CI/CD pipeline (e.g. GitHub Actions)
     MCP: 'MCP', // Job started trough apify client triggered from apify-mcp-server
+    APIFY_AI: 'APIFY_AI', // Job started from Apify AI chat (via MCP server)
 } as const;
 
 /**

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -8,6 +8,7 @@ import {
     LOCAL_ACTOR_ENV_VARS,
     LOCAL_APIFY_ENV_VARS,
     LOCAL_ENV_VARS,
+    META_ORIGINS,
     PROFILE_NAME,
     USERNAME,
 } from '@apify/consts';
@@ -147,6 +148,18 @@ describe('consts', () => {
             Object.keys(LOCAL_APIFY_ENV_VARS).forEach((k) => {
                 expect(k.startsWith('APIFY_')).toBe(true);
             });
+        });
+    });
+
+    describe('META_ORIGINS', () => {
+        it('every value is the same as its key', () => {
+            Object.entries(META_ORIGINS).forEach(([k, v]) => {
+                expect(v).toBe(k);
+            });
+        });
+
+        it('includes APIFY_AI', () => {
+            expect(META_ORIGINS.APIFY_AI).toBe('APIFY_AI');
         });
     });
 });

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -8,7 +8,6 @@ import {
     LOCAL_ACTOR_ENV_VARS,
     LOCAL_APIFY_ENV_VARS,
     LOCAL_ENV_VARS,
-    META_ORIGINS,
     PROFILE_NAME,
     USERNAME,
 } from '@apify/consts';
@@ -148,18 +147,6 @@ describe('consts', () => {
             Object.keys(LOCAL_APIFY_ENV_VARS).forEach((k) => {
                 expect(k.startsWith('APIFY_')).toBe(true);
             });
-        });
-    });
-
-    describe('META_ORIGINS', () => {
-        it('every value is the same as its key', () => {
-            Object.entries(META_ORIGINS).forEach(([k, v]) => {
-                expect(v).toBe(k);
-            });
-        });
-
-        it('includes APIFY_AI', () => {
-            expect(META_ORIGINS.APIFY_AI).toBe('APIFY_AI');
         });
     });
 });


### PR DESCRIPTION
Adds `APIFY_AI` to `META_ORIGINS` so Actor runs started from Apify AI chat get their own origin 

context: https://github.com/apify/apify-core/issues/29228