### PR TITLE
feat:  do not connect to analytics node in healthchecks

### DIFF
--- a/packages/utilities/src/health_checker.ts
+++ b/packages/utilities/src/health_checker.ts
@@ -114,7 +114,15 @@ export class HealthChecker {
     }
 
     async _testMongoDbPing({ client }: CheckType) {
-        const response = await client.command({ ping: 1 });
+        const response = await client.command(
+            { ping: 1 },
+            {
+                readPreference: {
+                    readPreference: 'nearest',
+                    readPreferenceTags: [{ nodeType: 'ELECTABLE' }],
+                },
+            },
+        );
         if (response.ok !== 1) throw new Error(`Got ${response.ok} instead of 1!`);
     }
 


### PR DESCRIPTION
Currently healthchecks pings are by default sent to all nodes, which causes issues which the analytics node is not replying.

This should skip the analytics node in healthchecks.