### PR TITLE
fix: reverted the read preference switch in healthcheck

### DIFF
--- a/packages/utilities/src/health_checker.ts
+++ b/packages/utilities/src/health_checker.ts
@@ -114,15 +114,7 @@ export class HealthChecker {
     }
 
     async _testMongoDbPing({ client }: CheckType) {
-        const response = await client.command(
-            { ping: 1 },
-            {
-                readPreference: {
-                    readPreference: 'nearest',
-                    readPreferenceTags: [{ nodeType: 'ELECTABLE' }],
-                },
-            },
-        );
+        const response = await client.command({ ping: 1 });
         if (response.ok !== 1) throw new Error(`Got ${response.ok} instead of 1!`);
     }
 


### PR DESCRIPTION
The read preference must be passed to the command as an instance of ReadPreference class from `mongodb` package, but we do not have this exported from the mongo-connection package, so that is not currently possible without adding `mongo` package. Reverting till we resolve it in apify-core...

<img width="2422" height="608" alt="CleanShot 2026-07-21 at 10 26 28@2x" src="https://github.com/user-attachments/assets/76589b60-3a67-4b4d-b744-ddd0949e243e" />
