### PR TITLE
feat(consts/exit-codes): add exit codes enum

### DIFF
--- a/packages/consts/src/consts.ts
+++ b/packages/consts/src/consts.ts
@@ -719,3 +719,18 @@ export const STORAGE_OWNERSHIP_FILTER = {
 } as const;
 
 export type STORAGE_OWNERSHIP_FILTER = ValueOf<typeof STORAGE_OWNERSHIP_FILTER>;
+
+/**
+ * Exit codes used by an Actor process to signal the outcome of its run.
+ * @see {@link https://whitepaper.actor/#exit-actor}
+ */
+export const ACTOR_EXIT_CODE = {
+    /** The Actor run finished successfully. */
+    SUCCESS: 0,
+    /** The Actor run failed due to an error. */
+    FAILURE: 1,
+    /** The Actor run failed because the provided input was invalid.*/
+    INVALID_INPUT: 2,
+} as const;
+
+export type ACTOR_EXIT_CODE = ValueOf<typeof ACTOR_EXIT_CODE>;


### PR DESCRIPTION
why? [thread](https://apify.slack.com/archives/C010Q0FBYG3/p1775123296474159) about a convention for failing actors due to an invalid input

After a talk with @B4nan we came to a conclusion that an enum here would be good enough for some ergonomics around this, so it can be used as:
```ts
await Actor.exit("your input sucks", { exitCode: ACTOR_EXIT_CODE.INVALID_INPUT });
```