### PR TITLE
chore: prepare repo infra for the next major releases

### DIFF
--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -2,9 +2,9 @@ name: Check & Release
 
 on:
     push:
-        branches: [ master, renovate/** ]
+        branches: [ master, next, renovate/** ]
     pull_request:
-        branches: [ master ]
+        branches: [ master, next ]
 
 jobs:
     test:
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [ 20, 22, 24 ]
+                node-version: [ 22, 24 ]
 
         steps:
             -   uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [ 22, 24 ]
+                node-version: [ 22, 24, 26 ]
 
         steps:
             -   uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "apify-shared",
     "private": true,
+    "type": "module",
     "description": "Tools and constants shared across Apify projects.",
     "keywords": [
         "apify"
@@ -67,7 +68,6 @@
         "oxlint-tsgolint": "0.22.0",
         "rimraf": "^6.0.1",
         "strip-ansi": "^6.0.0",
-        "ts-node": "^10.9.2",
         "tsup": "^8.3.0",
         "typescript": "^5.8.3",
         "underscore": "^1.13.7",

--- a/packages/actor-memory-expression/package.json
+++ b/packages/actor-memory-expression/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/consts/package.json
+++ b/packages/consts/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/datastructures/package.json
+++ b/packages/datastructures/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/image_proxy_client/package.json
+++ b/packages/image_proxy_client/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/input_schema/package.json
+++ b/packages/input_schema/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/input_secrets/package.json
+++ b/packages/input_secrets/package.json
@@ -38,7 +38,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/json_schemas/package.json
+++ b/packages/json_schemas/package.json
@@ -40,7 +40,7 @@
         "clean": "rimraf ./dist",
         "compile": "tsup",
         "build-schemas": "tsx scripts/build-schemas.ts",
-        "copy": "tsx ../../scripts/copy.ts",
+        "copy": "node ../../scripts/copy.ts",
         "describe-schemas": "tsx scripts/describe-schemas.ts",
         "build-ide-schemas": "tsx scripts/build-ide-schemas.ts",
         "process-schemas": "pnpm build-schemas && pnpm describe-schemas && pnpm build-ide-schemas"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/payment_qr_codes/package.json
+++ b/packages/payment_qr_codes/package.json
@@ -41,7 +41,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/pseudo_url/package.json
+++ b/packages/pseudo_url/package.json
@@ -38,7 +38,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/timeout/package.json
+++ b/packages/timeout/package.json
@@ -41,7 +41,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -42,7 +42,7 @@
         "build": "pnpm clean && pnpm compile && pnpm copy",
         "clean": "rimraf ./dist",
         "compile": "tsup",
-        "copy": "ts-node -T ../../scripts/copy.ts"
+        "copy": "node ../../scripts/copy.ts"
     },
     "publishConfig": {
         "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       strip-ansi:
         specifier: ^6.0.0
         version: 6.0.1
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.12.2)(typescript@5.9.3)
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.24)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -352,10 +349,6 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
-
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -712,9 +705,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
@@ -1494,18 +1484,6 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -1625,10 +1603,6 @@ packages:
     resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
     engines: {node: '>=0.4.0'}
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1685,9 +1659,6 @@ packages:
 
   aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2040,9 +2011,6 @@ packages:
   create-hmac@1.1.7:
     resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2115,10 +2083,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
@@ -2965,9 +2929,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   make-fetch-happen@15.0.2:
     resolution: {integrity: sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==}
@@ -3920,20 +3881,6 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -4028,9 +3975,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   vali-date@1.0.0:
     resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
@@ -4251,10 +4195,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
@@ -4409,10 +4349,6 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       conventional-commits-parser: 6.4.0
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4678,11 +4614,6 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5278,14 +5209,6 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@tufjs/canonical-json@2.0.0': {}
 
   '@tufjs/models@4.1.0':
@@ -5417,10 +5340,6 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-
   acorn@8.16.0: {}
 
   add-stream@1.0.0: {}
@@ -5466,8 +5385,6 @@ snapshots:
   any-promise@1.3.0: {}
 
   aproba@2.0.0: {}
-
-  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -5864,8 +5781,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-require@1.1.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5922,8 +5837,6 @@ snapshots:
   deprecation@2.3.1: {}
 
   detect-libc@2.1.2: {}
-
-  diff@4.0.4: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -6803,8 +6716,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
-
-  make-error@1.3.6: {}
 
   make-fetch-happen@15.0.2:
     dependencies:
@@ -8012,24 +7923,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@24.12.2)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.12.2
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -8117,8 +8010,6 @@ snapshots:
   upath@2.0.1: {}
 
   util-deprecate@1.0.2: {}
-
-  v8-compile-cache-lib@3.0.1: {}
 
   vali-date@1.0.0: {}
 
@@ -8305,7 +8196,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yn@3.1.1: {}
 
   yoctocolors-cjs@2.1.3: {}

--- a/scripts/copy.ts
+++ b/scripts/copy.ts
@@ -13,7 +13,7 @@ function rewrite(path: string, replacer: (from: string) => string): void {
 
 // as we publish only the dist folder, we need to copy some meta files inside (readme/license/package.json)
 // also changes paths inside the copied `package.json` (`dist/index.js` -> `index.js`)
-const root = resolve(__dirname, '..');
+const root = resolve(import.meta.dirname, '..');
 const target = resolve(process.cwd(), 'dist');
 
 copy('README.md', root, target);

--- a/scripts/sync-root-changelog.ts
+++ b/scripts/sync-root-changelog.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 // this script should be called with output from `lerna ls --json`, like:
-// `lerna ls --json | ts-node -T scripts/sync-root-changelog.ts`
+// `lerna ls --json | node scripts/sync-root-changelog.ts`
 const stdin = process.openStdin();
 let data = '';
 


### PR DESCRIPTION
Prep work for the upcoming major releases (ESM-only, Node 22+). The work lands on the `next` integration branch and gets fast-forwarded to `master` once complete.

- Run CI for pushes and PRs targeting `next`
- Drop Node 20 from the test matrix, keeping 22 and 24
- Run `scripts/copy.ts` with Node's native type stripping instead of `ts-node`, and drop the `ts-node` dev dependency. The root package is now `"type": "module"` so the script runs as ESM.
