### PR TITLE
ci: support publishing beta prereleases from non-default branches

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -17,6 +17,10 @@ permissions:
     id-token: write # Required for OIDC
     contents: write # Required to push changelog/lock file updates
 
+# Serialize publishes: concurrent runs would compute the same beta prerelease numbers from the registry
+concurrency:
+    group: publish_to_npm
+
 jobs:
     publish_to_npm:
         name: Publish to NPM

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -7,6 +7,11 @@ on:
                 description: Git ref to publish (branch, tag, or commit SHA)
                 required: true
                 type: string
+            prerelease:
+                description: Publish as a beta prerelease (versions like X.Y.Z-beta.N, npm dist-tag `next`, no tags/commits/releases)
+                required: false
+                default: false
+                type: boolean
 
 permissions:
     id-token: write # Required for OIDC
@@ -62,7 +67,20 @@ jobs:
             # 3. Commit and push all the changes via our signed commit action,
             #    and push tags created in 1. via API to have them signed as well
             # 4. Publish to NPM based on the versions in package.json
+            # Beta prereleases leave no trace in git: no tags, no pushed commits, no GitHub releases.
+            # The bump level comes from conventional commits since the last stable tag, and the
+            # prerelease number from the npm registry (see scripts/resolve-beta-versions.ts). The
+            # local commit below is a throwaway lerna needs to see a clean tree; it is never pushed.
+            - name: Version packages (beta prerelease)
+              if: ${{ inputs.prerelease }}
+              run: |
+                  git checkout -- .
+                  pnpm exec lerna version --conventional-prerelease --preid beta --no-push --no-git-tag-version --no-changelog --yes
+                  node scripts/resolve-beta-versions.ts
+                  git -c user.name="Apify Release Bot" -c user.email="noreply@apify.com" commit -am "chore: beta versions [local only]"
+
             - name: Version packages
+              if: ${{ !inputs.prerelease }}
               id: version_packages
               run: |
                   git checkout -- .
@@ -83,11 +101,13 @@ jobs:
                   GIT_COMMITTER_EMAIL: "noreply@apify.com"
 
             - name: Sync root changelog
+              if: ${{ !inputs.prerelease }}
               run: |
                   pnpm install --no-frozen-lockfile # reinstall to have updated lock file
                   pnpm exec lerna ls --json | node scripts/sync-root-changelog.ts
 
             - name: Commit and push changes
+              if: ${{ !inputs.prerelease }}
               id: signed_commit
               uses: apify/actions/signed-commit@v1.4.0
               with:
@@ -95,6 +115,7 @@ jobs:
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Push tags via API to have them signed
+              if: ${{ !inputs.prerelease }}
               run: |
                   while IFS= read -r tag; do
                       [ -z "$tag" ] && continue
@@ -108,4 +129,4 @@ jobs:
                   COMMIT_SHA: ${{ steps.signed_commit.outputs.commit_long_sha }}
 
             - name: Publish to NPM
-              run: pnpm exec lerna publish from-package --contents dist --yes
+              run: pnpm exec lerna publish from-package --contents dist --yes ${{ inputs.prerelease && '--dist-tag next' || '' }}

--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -79,7 +79,7 @@ jobs:
 
     publish:
         name: Publish to NPM
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/next'
         needs: [ test, build, lint, format-check ]
         runs-on: ubuntu-latest
         steps:
@@ -102,5 +102,6 @@ jobs:
                     workflow: publish_to_npm.yaml
                     inputs: >
                         {
-                            "ref": "master"
+                            "ref": "${{ github.ref_name }}",
+                            "prerelease": "${{ github.ref == 'refs/heads/next' }}"
                         }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,22 @@ Commit message itself should always be imperative (e.g. `add new logger`), and w
 Keep message clean, simple and short. When needed, use extended description on new line (keep one
 empty line to separate subject and body).
 
+## Beta releases from the `next` branch
+
+Stable releases are published automatically from `master`. The `next` branch is a long-lived prerelease
+channel: every push to it (any bump size — `fix`, `feat` or breaking) automatically publishes the changed
+packages as beta versions under the `next` npm dist-tag, installable with `npm install @apify/<pkg>@next`.
+
+Unlike stable releases, betas leave no trace in the repository: no version commits, no tags, no GitHub
+releases and no changelog updates. The bump level is computed from conventional commits since the last
+stable release (so accumulated breaking changes produce e.g. `3.0.0-beta.N`), and the prerelease number
+comes from what is already published on npm (see `scripts/resolve-beta-versions.ts`). Because nothing is
+recorded in git, versions in `package.json` stay at the last stable release.
+
+To release the accumulated changes as stable, merge (or fast-forward) `next` into `master` — the regular
+`master` publish then computes the stable versions from the same conventional commits. The **Publish to
+NPM** workflow can also be dispatched manually with the `prerelease` flag for betas from any other branch.
+
 ## Adding new package
 
 This repository is managed via `lerna` and pnpm workspaces. When adding new package, be sure to include all

--- a/scripts/resolve-beta-versions.ts
+++ b/scripts/resolve-beta-versions.ts
@@ -1,0 +1,50 @@
+/* eslint-disable no-console */
+import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Run after `lerna version --conventional-prerelease --no-git-tag-version`: since beta releases
+// leave no tags or commits behind, lerna always computes `X.Y.Z-beta.0`. The npm registry is the
+// only record of published betas, so this rewrites the prerelease number to the next free one.
+const packagesDir = resolve(import.meta.dirname, '..', 'packages');
+
+for (const dir of readdirSync(packagesDir)) {
+    const pkgPath = resolve(packagesDir, dir, 'package.json');
+    let pkg: { name: string; version: string };
+
+    try {
+        pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    } catch {
+        continue;
+    }
+
+    const match = /^(\d+\.\d+\.\d+)-beta\.\d+$/.exec(pkg.version);
+    if (!match) continue;
+
+    const base = match[1];
+    let published: string[] = [];
+
+    try {
+        published = JSON.parse(execSync(`npm show ${pkg.name} versions --json`, { encoding: 'utf8', stdio: 'pipe' }));
+    } catch {
+        // the package might not have been published yet
+    }
+
+    if (published.includes(base)) {
+        console.error(`${pkg.name}: stable ${base} is already published, refusing to compute a beta for it`);
+        process.exit(1);
+    }
+
+    const betaNumbers = published
+        .filter((v) => v.startsWith(`${base}-beta.`))
+        .map((v) => Number(v.slice(`${base}-beta.`.length)))
+        .filter(Number.isInteger);
+    const next = Math.max(-1, ...betaNumbers) + 1;
+
+    const version = `${base}-beta.${next}`;
+    console.info(`${pkg.name}: ${pkg.version} -> ${version}`);
+    writeFileSync(
+        pkgPath,
+        readFileSync(pkgPath, 'utf8').replace(`"version": "${pkg.version}"`, `"version": "${version}"`),
+    );
+}

--- a/scripts/resolve-beta-versions.ts
+++ b/scripts/resolve-beta-versions.ts
@@ -26,8 +26,9 @@ for (const dir of readdirSync(packagesDir)) {
 
     try {
         published = JSON.parse(execSync(`npm show ${pkg.name} versions --json`, { encoding: 'utf8', stdio: 'pipe' }));
-    } catch {
-        // the package might not have been published yet
+    } catch (err) {
+        // E404 means the package was never published; anything else must not silently disable the guard below
+        if (!String((err as { stderr?: unknown }).stderr ?? '').includes('E404')) throw err;
     }
 
     if (published.includes(base)) {

--- a/scripts/resolve-beta-versions.ts
+++ b/scripts/resolve-beta-versions.ts
@@ -43,8 +43,8 @@ for (const dir of readdirSync(packagesDir)) {
 
     const version = `${base}-beta.${next}`;
     console.info(`${pkg.name}: ${pkg.version} -> ${version}`);
-    writeFileSync(
-        pkgPath,
-        readFileSync(pkgPath, 'utf8').replace(`"version": "${pkg.version}"`, `"version": "${version}"`),
-    );
+    const source = readFileSync(pkgPath, 'utf8');
+    const updated = source.replace(`"version": "${pkg.version}"`, `"version": "${version}"`);
+    if (updated === source) throw new Error(`${pkg.name}: failed to rewrite the version in ${pkgPath}`);
+    writeFileSync(pkgPath, updated);
 }


### PR DESCRIPTION
Every push to `next` now automatically publishes the changed packages as beta prereleases under the `next` npm dist-tag (`npm install @apify/<pkg>@next`), so the upcoming majors can be tested end to end (crawlee e2e suite and elsewhere) before the fast-forward to `master`. The `next` branch stays a long-lived prerelease channel afterwards, usable for betas of patch/minor bumps the same way.

Like in crawlee, betas leave no trace in git: no version commits, no tags, no GitHub releases, no changelog updates. The mechanics:

- `lerna version --conventional-prerelease --preid beta --no-push --no-git-tag-version --no-changelog` computes the bump level from conventional commits since the last stable release (accumulated breaking changes produce one major, e.g. `3.0.0-beta.N`, and the four 0.x packages go to `1.0.0-beta.N`)
- since git records nothing, lerna alone would always produce `beta.0`; `scripts/resolve-beta-versions.ts` rewrites the prerelease number to the next free one according to the npm registry (crawlee's approach, adapted for independent versioning)
- a throwaway local commit keeps the tree clean for `lerna publish from-package --dist-tag next`; it is never pushed
- stable releases from `master` are untouched: the same conventional commits then produce the stable versions, so no graduation step is needed

Verified on a scratch clone: the lerna invocation skips tags/commits/releases as expected and proposes the right versions for all 14 packages, and the beta-number logic was checked against real registry data. The manual `workflow_dispatch` path also accepts the `prerelease` flag for betas from other branches. Documented in CONTRIBUTING.md. Stacked on the zod PR.
