### PR TITLE
fix(json_schemas): make the input schema validator compile under ajv strict mode

### DIFF
--- a/packages/json_schemas/output/actor.ide.json
+++ b/packages/json_schemas/output/actor.ide.json
@@ -2406,7 +2406,6 @@
                                 ]
                             },
                             "uniqueItems": true,
-                            "additionalItems": false,
                             "minItems": 1,
                             "description": "Allowed type for the input value. Cannot be mixed.",
                             "x-intellij-html-description": "<p>Allowed type for the input value. Cannot be mixed.</p>",

--- a/packages/json_schemas/output/input.ide.json
+++ b/packages/json_schemas/output/input.ide.json
@@ -2106,7 +2106,6 @@
                         ]
                     },
                     "uniqueItems": true,
-                    "additionalItems": false,
                     "minItems": 1,
                     "description": "Allowed type for the input value. Cannot be mixed.",
                     "x-intellij-html-description": "<p>Allowed type for the input value. Cannot be mixed.</p>",

--- a/packages/json_schemas/output/input.json
+++ b/packages/json_schemas/output/input.json
@@ -2107,7 +2107,6 @@
                         ]
                     },
                     "uniqueItems": true,
-                    "additionalItems": false,
                     "minItems": 1,
                     "description": "Allowed type for the input value. Cannot be mixed.",
                     "x-intellij-html-description": "<p>Allowed type for the input value. Cannot be mixed.</p>",

--- a/packages/json_schemas/schemas/input.schema.json
+++ b/packages/json_schemas/schemas/input.schema.json
@@ -708,7 +708,6 @@
                         "enum": ["object", "array", "string", "integer", "number", "boolean"]
                     },
                     "uniqueItems": true,
-                    "additionalItems": false,
                     "minItems": 1
                 },
                 "title": { "type": "string" },

--- a/test/json_schemas_validators.test.ts
+++ b/test/json_schemas_validators.test.ts
@@ -8,8 +8,7 @@ import {
     getOutputSchemaValidator,
 } from '@apify/json_schemas';
 
-// Regression test: `getInputSchemaValidator()` used to throw on first call, because ajv's strict
-// mode rejects the dead `additionalItems` keyword the input schema carried next to a non-tuple `items`.
+// Regression test: ajv's strict mode rejects `additionalItems` next to a non-tuple `items`, which made `getInputSchemaValidator()` throw.
 describe('json_schemas validators', () => {
     it.each([
         ['actor', getActorSchemaValidator],

--- a/test/json_schemas_validators.test.ts
+++ b/test/json_schemas_validators.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    getActorSchemaValidator,
+    getDatasetSchemaValidator,
+    getInputSchemaValidator,
+    getKeyValueStoreSchemaValidator,
+    getOutputSchemaValidator,
+} from '@apify/json_schemas';
+
+// Regression test: `getInputSchemaValidator()` used to throw on first call, because ajv's strict
+// mode rejects the dead `additionalItems` keyword the input schema carried next to a non-tuple `items`.
+describe('json_schemas validators', () => {
+    it.each([
+        ['actor', getActorSchemaValidator],
+        ['dataset', getDatasetSchemaValidator],
+        ['input', getInputSchemaValidator],
+        ['key-value store', getKeyValueStoreSchemaValidator],
+        ['output', getOutputSchemaValidator],
+    ])('%s schema compiles into a validator', (_name, getValidator) => {
+        const validate = getValidator();
+        expect(typeof validate).toBe('function');
+        expect(validate({})).toBe(false);
+    });
+
+    it('input schema validator accepts a minimal valid schema', () => {
+        const validate = getInputSchemaValidator();
+        const valid = validate({
+            title: 'Test input',
+            type: 'object',
+            schemaVersion: 1,
+            properties: {
+                query: { title: 'Query', description: 'Search query', type: 'string', editor: 'textfield' },
+            },
+        });
+        expect(validate.errors).toBeNull();
+        expect(valid).toBe(true);
+    });
+});


### PR DESCRIPTION
`getInputSchemaValidator()` from `@apify/json_schemas` threw on first call, in the published package too: the input schema carried a dead `"additionalItems": false` next to a non-tuple `items`, and ajv's strict mode rejects the combination while compiling. The keyword was a no-op (schema-form `items` already constrains every element), so removing it changes no validation behavior. Found during review of the ESM stack.

Adds regression coverage compiling all five validators plus a happy-path check of the input one. Stacked on #686.
