### PR TITLE
feat(markdown): update marked to v18

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -45,7 +45,7 @@
     "dependencies": {
         "@apify/consts": "workspace:^",
         "@apify/utilities": "workspace:^",
-        "marked": "^15.0.0",
+        "marked": "^18.0.0",
         "match-all": "^1.2.6"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: workspace:^
         version: link:../utilities
       marked:
-        specifier: ^15.0.0
-        version: 15.0.12
+        specifier: ^18.0.0
+        version: 18.0.11
       match-all:
         specifier: ^1.2.6
         version: 1.2.7
@@ -2940,9 +2940,9 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
+  marked@18.0.11:
+    resolution: {integrity: sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   match-all@1.2.7:
@@ -6736,7 +6736,7 @@ snapshots:
 
   map-obj@4.3.0: {}
 
-  marked@15.0.12: {}
+  marked@18.0.11: {}
 
   match-all@1.2.7: {}
 


### PR DESCRIPTION
Bumps `marked` from v15 to v18 in `@apify/markdown`. No code changes were needed: the whole suite, including the marked and renderer tests, passes as is. Stacked on the json_schemas fix PR.

One rendering delta found by an A/B comparison against v15 across ~35 markdown samples: v18 trims trailing blank lines after raw HTML block tokens, so two inline HTML elements separated by a blank line (side-by-side badge images, typically) now render with no space between them. Everything else, lists and loose lists included, renders identically.
