### PR TITLE
feat(git): replace git-url-parse with a small built-in parser

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -42,9 +42,6 @@
     "publishConfig": {
         "access": "public"
     },
-    "dependencies": {
-        "git-url-parse": "^16.0.0"
-    },
     "engines": {
         "node": ">=22"
     }

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -21,7 +21,7 @@ interface ParsedGitUrl {
  * `ssh://git@github.com/owner/repo.git`, ...). Deeper path segments (e.g. Bitbucket's `/src/...`
  * suffix) are ignored.
  */
-const parseGitUrl = (gitRepoUrl: string): { resource: string; fullName: string } => {
+const parseGitUrl = (gitRepoUrl: string): Omit<ParsedGitUrl, 'branchName'> => {
     let resource: string;
     let path: string;
 
@@ -74,8 +74,8 @@ export const convertRelativeImagePathsToAbsoluteInReadme = ({
     const parsedRepoUrl = parseApifyGitUrl(gitRepoUrl);
     const repoFullName = parsedRepoUrl.fullName;
 
-    // We need to parse the branch there hence gitUrlParse is not detected this format of git URL.
-    // Otherwise, we try to use the branch name from the build object. It should exist for all builds since roughly mid October 2020.
+    // The branch from the URL hash takes precedence over the branch name from the build object.
+    // The latter should exist for all builds since roughly mid October 2020.
     // Prior to that, all default branches were 'master', hence we default to that as a backup.
     const branchName = parsedRepoUrl.branchName || gitBranchName || 'master';
 

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -1,5 +1,3 @@
-import gitUrlParse from 'git-url-parse';
-
 interface ConvertOptions {
     /** whole readme file stored as a single string */
     readme: string;
@@ -9,9 +7,41 @@ interface ConvertOptions {
     gitBranchName?: string;
 }
 
-interface ParseGitUrl extends gitUrlParse.GitUrl {
+interface ParsedGitUrl {
+    /** host of the repo, e.g. `github.com` */
+    resource: string;
+    /** `owner/repo` part of the URL, without the `.git` suffix or any deeper path */
+    fullName: string;
     branchName?: string;
 }
+
+/**
+ * Parses the host and `owner/repo` pair from a git repo URL, either in the scp-like form
+ * (`git@github.com:owner/repo.git`) or any URL form (`https://github.com/owner/repo.git`,
+ * `ssh://git@github.com/owner/repo.git`, ...). Deeper path segments (e.g. Bitbucket's `/src/...`
+ * suffix) are ignored.
+ */
+const parseGitUrl = (gitRepoUrl: string): { resource: string; fullName: string } => {
+    let resource: string;
+    let path: string;
+
+    const scpLikeMatch = /^(?:[^@/]+@)?([^:/@]+):(.+)$/.exec(gitRepoUrl);
+    if (scpLikeMatch && !gitRepoUrl.includes('://')) {
+        [, resource, path] = scpLikeMatch;
+    } else {
+        const url = new URL(gitRepoUrl);
+        resource = url.hostname;
+        path = url.pathname;
+    }
+
+    const pathParts = path.replace(/^\/+/, '').split('/');
+    const fullName = pathParts
+        .slice(0, 2)
+        .join('/')
+        .replace(/\.git$/, '');
+
+    return { resource, fullName };
+};
 
 /**
  * Apify uses an extended git URL format with branch and directory as hash parameters:
@@ -20,24 +50,13 @@ interface ParseGitUrl extends gitUrlParse.GitUrl {
  * - myrepo.git#branch:folder
  * see https://github.com/apify/apify-worker/blob/8a667b3b5879a78ec2ce6a06e4953ad174b47cf2/src/actor/act2_build_job.js#L1258
  * @param gitRepoUrl
- * @return {ParseGitUrl}
+ * @return {ParsedGitUrl}
  */
-const parseApifyGitUrl = (gitRepoUrl: string): ParseGitUrl => {
-    if (gitRepoUrl.includes('#')) {
-        const repoFullUrlParsed = gitRepoUrl.split('#');
-        const repoUrl = repoFullUrlParsed[0];
-        const branchDirPart = repoFullUrlParsed[1];
-        const parsedRepoUrl = gitUrlParse(repoUrl);
-        let branchName;
-        if (branchDirPart && branchDirPart.includes(':')) {
-            const [branchPart] = branchDirPart.split(':');
-            branchName = branchPart;
-        } else if (branchDirPart) {
-            branchName = branchDirPart;
-        }
-        return { ...parsedRepoUrl, branchName };
-    }
-    return gitUrlParse(gitRepoUrl);
+const parseApifyGitUrl = (gitRepoUrl: string): ParsedGitUrl => {
+    const [repoUrl, branchDirPart] = gitRepoUrl.split('#');
+    // the part before `:` is the branch name; `#:folder` and a plain `#` carry no branch
+    const branchName = branchDirPart?.split(':')[0] || undefined;
+    return { ...parseGitUrl(repoUrl), branchName };
 };
 
 /**
@@ -53,10 +72,7 @@ export const convertRelativeImagePathsToAbsoluteInReadme = ({
     gitBranchName,
 }: ConvertOptions): string => {
     const parsedRepoUrl = parseApifyGitUrl(gitRepoUrl);
-
-    // Can't use parsedRepoUrl.full_name on it's own as Bitbucket adds irrelevant path suffix to the end of it
-    const repoNameParts = parsedRepoUrl.full_name.split('/');
-    const repoFullName = `${repoNameParts[0]}/${repoNameParts[1]}`;
+    const repoFullName = parsedRepoUrl.fullName;
 
     // We need to parse the branch there hence gitUrlParse is not detected this format of git URL.
     // Otherwise, we try to use the branch name from the build object. It should exist for all builds since roughly mid October 2020.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,11 +97,7 @@ importers:
 
   packages/datastructures: {}
 
-  packages/git:
-    dependencies:
-      git-url-parse:
-        specifier: ^16.0.0
-        version: 16.1.0
+  packages/git: {}
 
   packages/image_proxy_client: {}
 
@@ -1342,10 +1338,6 @@ packages:
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
-  '@types/parse-path@7.1.0':
-    resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
-    deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
-
   '@types/safe-regex@1.1.6':
     resolution: {integrity: sha512-CQ/uPB9fLOPKwDsrTeVbNIkwfUthTWOx0l6uIGwVFjZxv7e68pCW5gtTYFzdJi3EBJp8h8zYhJbTasAbX7gEMQ==}
 
@@ -2109,14 +2101,8 @@ packages:
   git-up@7.0.0:
     resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
 
-  git-up@8.1.1:
-    resolution: {integrity: sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==}
-
   git-url-parse@14.0.0:
     resolution: {integrity: sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==}
-
-  git-url-parse@16.1.0:
-    resolution: {integrity: sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==}
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
@@ -2838,10 +2824,6 @@ packages:
 
   parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
-
-  parse-url@9.2.0:
-    resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
-    engines: {node: '>=14.13.0'}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -4403,10 +4385,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/parse-path@7.1.0':
-    dependencies:
-      parse-path: 7.1.0
-
   '@types/safe-regex@1.1.6': {}
 
   '@types/showdown@2.0.6': {}
@@ -5135,18 +5113,9 @@ snapshots:
       is-ssh: 1.4.1
       parse-url: 8.1.0
 
-  git-up@8.1.1:
-    dependencies:
-      is-ssh: 1.4.1
-      parse-url: 9.2.0
-
   git-url-parse@14.0.0:
     dependencies:
       git-up: 7.0.0
-
-  git-url-parse@16.1.0:
-    dependencies:
-      git-up: 8.1.1
 
   glob@11.1.0:
     dependencies:
@@ -6116,11 +6085,6 @@ snapshots:
 
   parse-url@8.1.0:
     dependencies:
-      parse-path: 7.1.0
-
-  parse-url@9.2.0:
-    dependencies:
-      '@types/parse-path': 7.1.0
       parse-path: 7.1.0
 
   parse5-htmlparser2-tree-adapter@7.1.0:

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -260,45 +260,33 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
         ).toEqual(testMarkdown);
     });
 
-    it('works with https repo URLs', () => {
-        const testMarkdown = '![img](./img.jpg)';
-
-        expect(
-            convertRelativeImagePathsToAbsoluteInReadme({
-                readme: testMarkdown,
-                gitRepoUrl: 'https://github.com/apify/test-repo.git',
-            }),
-        ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/master/img.jpg)');
-
-        expect(
-            convertRelativeImagePathsToAbsoluteInReadme({
-                readme: testMarkdown,
-                gitRepoUrl: 'https://github.com/apify/test-repo.git#dev',
-            }),
-        ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/dev/img.jpg)');
-
+    it.each([
+        [
+            'https://github.com/apify/test-repo.git',
+            undefined,
+            'https://raw.githubusercontent.com/apify/test-repo/master',
+        ],
+        [
+            'https://github.com/apify/test-repo.git#dev',
+            undefined,
+            'https://raw.githubusercontent.com/apify/test-repo/dev',
+        ],
         // `#:folder` carries only a folder, no branch, so the default branch is used
-        expect(
-            convertRelativeImagePathsToAbsoluteInReadme({
-                readme: testMarkdown,
-                gitRepoUrl: 'https://github.com/apify/test-repo.git#:folder',
-            }),
-        ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/master/img.jpg)');
-
+        [
+            'https://github.com/apify/test-repo.git#:folder',
+            undefined,
+            'https://raw.githubusercontent.com/apify/test-repo/master',
+        ],
         // Bitbucket web URLs carry a path suffix after owner/repo, which must be ignored
+        [
+            'https://user@bitbucket.org/apify/test-repo/src/main/',
+            'main',
+            'https://bytebucket.org/apify/test-repo/raw/main',
+        ],
+        ['ssh://git@gitlab.com/apify/test-repo.git', undefined, 'https://gitlab.com/apify/test-repo/-/raw/master'],
+    ])('works with URL-style repo URL %s', (gitRepoUrl, gitBranchName, expectedPrefix) => {
         expect(
-            convertRelativeImagePathsToAbsoluteInReadme({
-                readme: testMarkdown,
-                gitRepoUrl: 'https://user@bitbucket.org/apify/test-repo/src/main/',
-                gitBranchName: 'main',
-            }),
-        ).toEqual('![img](https://bytebucket.org/apify/test-repo/raw/main/img.jpg)');
-
-        expect(
-            convertRelativeImagePathsToAbsoluteInReadme({
-                readme: testMarkdown,
-                gitRepoUrl: 'ssh://git@gitlab.com/apify/test-repo.git',
-            }),
-        ).toEqual('![img](https://gitlab.com/apify/test-repo/-/raw/master/img.jpg)');
+            convertRelativeImagePathsToAbsoluteInReadme({ readme: '![img](./img.jpg)', gitRepoUrl, gitBranchName }),
+        ).toEqual(`![img](${expectedPrefix}/img.jpg)`);
     });
 });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -277,6 +277,14 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
             }),
         ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/dev/img.jpg)');
 
+        // `#:folder` carries only a folder, no branch, so the default branch is used
+        expect(
+            convertRelativeImagePathsToAbsoluteInReadme({
+                readme: testMarkdown,
+                gitRepoUrl: 'https://github.com/apify/test-repo.git#:folder',
+            }),
+        ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/master/img.jpg)');
+
         // Bitbucket web URLs carry a path suffix after owner/repo, which must be ignored
         expect(
             convertRelativeImagePathsToAbsoluteInReadme({

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -259,4 +259,38 @@ describe('convertRelativeImagePathsToAbsoluteInReadme()', () => {
             }),
         ).toEqual(testMarkdown);
     });
+
+    it('works with https repo URLs', () => {
+        const testMarkdown = '![img](./img.jpg)';
+
+        expect(
+            convertRelativeImagePathsToAbsoluteInReadme({
+                readme: testMarkdown,
+                gitRepoUrl: 'https://github.com/apify/test-repo.git',
+            }),
+        ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/master/img.jpg)');
+
+        expect(
+            convertRelativeImagePathsToAbsoluteInReadme({
+                readme: testMarkdown,
+                gitRepoUrl: 'https://github.com/apify/test-repo.git#dev',
+            }),
+        ).toEqual('![img](https://raw.githubusercontent.com/apify/test-repo/dev/img.jpg)');
+
+        // Bitbucket web URLs carry a path suffix after owner/repo, which must be ignored
+        expect(
+            convertRelativeImagePathsToAbsoluteInReadme({
+                readme: testMarkdown,
+                gitRepoUrl: 'https://user@bitbucket.org/apify/test-repo/src/main/',
+                gitBranchName: 'main',
+            }),
+        ).toEqual('![img](https://bytebucket.org/apify/test-repo/raw/main/img.jpg)');
+
+        expect(
+            convertRelativeImagePathsToAbsoluteInReadme({
+                readme: testMarkdown,
+                gitRepoUrl: 'ssh://git@gitlab.com/apify/test-repo.git',
+            }),
+        ).toEqual('![img](https://gitlab.com/apify/test-repo/-/raw/master/img.jpg)');
+    });
 });


### PR DESCRIPTION
`@apify/git` only needs the host and the `owner/repo` pair from the repo URL, so a `URL` constructor plus one regex for the scp-like form (`git@host:owner/repo.git`) replaces `git-url-parse`. That drops the `git-url-parse` -> `git-up` -> `parse-url` -> `parse-path` -> `protocols` chain, five packages with a history of ReDoS advisories (the broken `normalize-url` typings we kept hitting in builds came from there too). The package now has zero dependencies.

Existing scp-style tests pass unchanged; new tests cover https, ssh and Bitbucket web URL forms (including the path suffix after `owner/repo` that the old code special-cased). Stacked on the uqr PR.
