### PR TITLE
chore: replace test and build dev dependencies with native equivalents

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,9 @@
     "devDependencies": {
         "@apify/oxlint-config": "^0.3.0",
         "@commitlint/config-conventional": "^21.0.0",
-        "@types/clone-deep": "^4.0.4",
         "@types/node": "^22.0.0",
-        "@types/underscore": "^1.11.15",
         "@vitest/coverage-v8": "^4.1.4",
         "ajv": "^8.17.1",
-        "clone-deep": "^4.0.1",
         "commitlint": "^21.0.0",
         "husky": "^9.1.4",
         "lerna": "^10.0.0",
@@ -65,10 +62,7 @@
         "oxfmt": "0.65.0",
         "oxlint": "1.80.0",
         "oxlint-tsgolint": "7.0.2001",
-        "rimraf": "^6.0.1",
-        "strip-ansi": "^7.0.0",
         "typescript": "^7.0.0",
-        "underscore": "^1.13.7",
         "vite": "^8.0.16",
         "vitest": "^4.1.4"
     },

--- a/packages/actor-memory-expression/package.json
+++ b/packages/actor-memory-expression/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/consts/package.json
+++ b/packages/consts/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/datastructures/package.json
+++ b/packages/datastructures/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/image_proxy_client/package.json
+++ b/packages/image_proxy_client/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/input_schema/package.json
+++ b/packages/input_schema/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/input_secrets/package.json
+++ b/packages/input_secrets/package.json
@@ -31,7 +31,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/json_schemas/package.json
+++ b/packages/json_schemas/package.json
@@ -32,7 +32,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm process-schemas && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "build-schemas": "node scripts/build-schemas.ts",
         "copy": "node ../../scripts/copy.ts",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/payment_qr_codes/package.json
+++ b/packages/payment_qr_codes/package.json
@@ -34,7 +34,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/pseudo_url/package.json
+++ b/packages/pseudo_url/package.json
@@ -31,7 +31,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/timeout/package.json
+++ b/packages/timeout/package.json
@@ -34,7 +34,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -35,7 +35,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/packages/validations/package.json
+++ b/packages/validations/package.json
@@ -31,7 +31,7 @@
     "homepage": "https://apify.com",
     "scripts": {
         "build": "pnpm clean && pnpm compile && pnpm copy",
-        "clean": "rimraf ./dist",
+        "clean": "node ../../scripts/clean.ts",
         "compile": "tsc -p tsconfig.build.json",
         "copy": "node ../../scripts/copy.ts"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,24 +20,15 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^21.0.0
         version: 21.2.2
-      '@types/clone-deep':
-        specifier: ^4.0.4
-        version: 4.0.4
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.1
-      '@types/underscore':
-        specifier: ^1.11.15
-        version: 1.13.0
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
-      clone-deep:
-        specifier: ^4.0.1
-        version: 4.0.1
       commitlint:
         specifier: ^21.0.0
         version: 21.2.2(@types/node@22.20.1)(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)(typescript@7.0.2)
@@ -62,18 +53,9 @@ importers:
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
-      strip-ansi:
-        specifier: ^7.0.0
-        version: 7.2.0
       typescript:
         specifier: ^7.0.0
         version: 7.0.2
-      underscore:
-        specifier: ^1.13.7
-        version: 1.13.8
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
@@ -1326,9 +1308,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/clone-deep@4.0.4':
-    resolution: {integrity: sha512-vXh6JuuaAha6sqEbJueYdh5zNBPPgG1OYumuz2UvLvriN6ABHDSW8ludREGWJb1MLIzbwZn4q4zUbUCerJTJfA==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1343,9 +1322,6 @@ packages:
 
   '@types/showdown@2.0.6':
     resolution: {integrity: sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==}
-
-  '@types/underscore@1.13.0':
-    resolution: {integrity: sha512-L6LBgy1f0EFQZ+7uSA57+n2g/s4Qs5r06Vwrwn0/nuK1de+adz00NWaztRQ30aEqw5qOaWbPI8u2cGQ52lj6VA==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1686,10 +1662,6 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
-
-  clone-deep@4.0.1:
-    resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
-    engines: {node: '>=6'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -2279,10 +2251,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
-    engines: {node: '>=0.10.0'}
-
   is-ssh@1.4.1:
     resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
 
@@ -2308,10 +2276,6 @@ packages:
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
-
-  isobject@3.0.1:
-    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
-    engines: {node: '>=0.10.0'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -2386,10 +2350,6 @@ packages:
 
   just-diff@6.0.2:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
-
-  kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
 
   lerna@10.0.1:
     resolution: {integrity: sha512-ibmMaBmH/sR2HpZzgvpEI5/6bCgMp0AISIFZ/cQcCzRVH2EgPapBYHXS6A6NgI6vRJNE4pgnxQbNiSq00HVSjA==}
@@ -2960,11 +2920,6 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
-  rimraf@6.1.3:
-    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3009,10 +2964,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  shallow-clone@3.0.1:
-    resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
-    engines: {node: '>=8'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3219,9 +3170,6 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-
-  underscore@1.13.8:
-    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4375,8 +4323,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/clone-deep@4.0.4': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -4388,8 +4334,6 @@ snapshots:
   '@types/safe-regex@1.1.6': {}
 
   '@types/showdown@2.0.6': {}
-
-  '@types/underscore@1.13.0': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -4699,12 +4643,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  clone-deep@4.0.1:
-    dependencies:
-      is-plain-object: 2.0.4
-      kind-of: 6.0.3
-      shallow-clone: 3.0.1
 
   clone@1.0.4: {}
 
@@ -5283,10 +5221,6 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
-
   is-ssh@1.4.1:
     dependencies:
       protocols: 2.0.2
@@ -5304,8 +5238,6 @@ snapshots:
   isexe@3.1.5: {}
 
   isexe@4.0.0: {}
-
-  isobject@3.0.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -5363,8 +5295,6 @@ snapshots:
   just-diff-apply@5.5.0: {}
 
   just-diff@6.0.2: {}
-
-  kind-of@6.0.3: {}
 
   lerna@10.0.1(@types/node@22.20.1)(typescript@7.0.2):
     dependencies:
@@ -6195,11 +6125,6 @@ snapshots:
 
   retry@0.12.0: {}
 
-  rimraf@6.1.3:
-    dependencies:
-      glob: 13.0.6
-      package-json-from-dist: 1.0.1
-
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -6242,10 +6167,6 @@ snapshots:
   semver@7.8.4: {}
 
   semver@7.8.5: {}
-
-  shallow-clone@3.0.1:
-    dependencies:
-      kind-of: 6.0.3
 
   shebang-command@2.0.0:
     dependencies:
@@ -6464,8 +6385,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
 

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -1,0 +1,3 @@
+import { rmSync } from 'node:fs';
+
+rmSync('dist', { recursive: true, force: true });

--- a/test/list_dictionary.test.ts
+++ b/test/list_dictionary.test.ts
@@ -1,7 +1,8 @@
-import _ from 'underscore';
 import { describe, expect, it } from 'vitest';
 
 import { ListDictionary } from '@apify/datastructures';
+
+const shuffledRange = (n: number) => Array.from({ length: n }, (_, i) => i).sort(() => Math.random() - 0.5);
 
 // asserts that linked list is equivalent to an array of [{key: Object, value: Object}] objects
 const assertSame = function (ld: any, array: any) {
@@ -149,7 +150,7 @@ describe('list_dictionary', () => {
             // try get existing items
             expect(ld.get('null')).toBe(null);
             expect(ld.get('')).toBe('empty');
-            const indexes = _.shuffle(_.range(50));
+            const indexes = shuffledRange(50);
             indexes.forEach((i) => {
                 expect(ld.get(`key${i}`)).toBe(`val${i}`);
                 assertSame(ld, array);
@@ -223,7 +224,7 @@ describe('list_dictionary', () => {
             expect(ld.remove('')).toBe(null);
             assertSame(ld, array);
 
-            const indexes = _.shuffle(_.range(50));
+            const indexes = shuffledRange(50);
             indexes.forEach((i) => {
                 expect(ld.remove(`key${i}`)).toBe(`val${i}`);
                 array = array.filter((elem) => {

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { APIFY_ENV_VARS } from '@apify/consts';

--- a/test/logger_text.test.ts
+++ b/test/logger_text.test.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { IS_APIFY_LOGGER_EXCEPTION, LoggerText, LogLevel, PREFIX_DELIMITER } from '@apify/log';

--- a/test/lru_cache.test.ts
+++ b/test/lru_cache.test.ts
@@ -1,7 +1,8 @@
-import _ from 'underscore';
 import { describe, expect, it } from 'vitest';
 
 import { LruCache } from '@apify/datastructures';
+
+const shuffledRange = (n: number) => Array.from({ length: n }, (_, i) => i).sort(() => Math.random() - 0.5);
 
 // asserts that linked list and dictionary is equivalent to an array of [{key: Object, value: Object}] objects
 const assertSame = function (lru: LruCache, array: any[]) {
@@ -167,7 +168,7 @@ describe('lru_cache', () => {
             // try get existing items
             expect(lru.get('null')).toBe(null);
             expect(lru.get('')).toBe('empty');
-            const indexes = _.shuffle(_.range(50));
+            const indexes = shuffledRange(50);
             indexes.forEach((i) => {
                 expect(lru.get(`key${i}`)).toBe(`val${i}`);
             });
@@ -251,7 +252,7 @@ describe('lru_cache', () => {
             expect(lru.remove('')).toBe(null);
             assertSame(lru, array);
 
-            const indexes = _.shuffle(_.range(50));
+            const indexes = shuffledRange(50);
             indexes.forEach((i) => {
                 expect(lru.remove(`key${i}`)).toBe(`val${i}`);
                 array = array.filter((elem) => elem.key !== `key${i}`);

--- a/test/utilities.client.test.ts
+++ b/test/utilities.client.test.ts
@@ -1,8 +1,6 @@
 import { createPublicKey } from 'node:crypto';
 
 import Ajv from 'ajv';
-import brokenClone from 'clone-deep';
-import _ from 'underscore';
 import { describe, expect, it } from 'vitest';
 
 import { validateInputUsingValidator } from '@apify/input_schema';
@@ -23,8 +21,12 @@ import {
 
 // @ts-ignore This clone doesn't work for array of NULLs (returns an empty array).
 
-const clone = function (obj: any) {
-    return Array.isArray(obj) ? obj.slice(0) : brokenClone(obj);
+const clone = function (obj: any): any {
+    if (obj === null || typeof obj !== 'object') return obj;
+    if (obj instanceof Date) return new Date(obj.getTime());
+    if (Buffer.isBuffer(obj)) return Buffer.from(obj);
+    if (Array.isArray(obj)) return obj.map((item) => clone(item));
+    return Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, clone(value)]));
 };
 
 const GOOD_OBJECTS = [
@@ -146,7 +148,7 @@ const BAD_IRREVERSIBLE_OBJECTS = [
     },
 ] as any;
 
-const BAD_OBJECTS = _.union(BAD_REVERSIBLE_OBJECTS, BAD_IRREVERSIBLE_OBJECTS);
+const BAD_OBJECTS = [...new Set([...BAD_REVERSIBLE_OBJECTS, ...BAD_IRREVERSIBLE_OBJECTS])];
 
 // this effectively tests _escapePropertyName() and _unescapePropertyName()
 const KNOWN_ESCAPES: { irreversible?: boolean; src: any; trg: any }[] = [
@@ -302,7 +304,7 @@ describe('utilities.client', () => {
 
         it('works with transformation', () => {
             const incrementDates = <T>(key: string, value: T): [string, T] => {
-                if (key.endsWith('At') && _.isDate(value)) {
+                if (key.endsWith('At') && value instanceof Date) {
                     return [key, new Date(value.getTime() + 1) as unknown as T];
                 }
                 return [key, value];
@@ -1928,7 +1930,7 @@ describe('utilities.client', () => {
 
             // Replacer removes number properties.
             const replacer = (key: string, val: any) => {
-                return _.isNumber(val) ? undefined : val;
+                return typeof val === 'number' ? undefined : val;
             };
 
             expect(jsonStringifyExtended(value, replacer, 2)).toBe(expected);

--- a/test/utilities.client.test.ts
+++ b/test/utilities.client.test.ts
@@ -19,8 +19,6 @@ import {
     unescapeFromBson,
 } from '@apify/utilities';
 
-// @ts-ignore This clone doesn't work for array of NULLs (returns an empty array).
-
 const clone = function (obj: any): any {
     if (obj === null || typeof obj !== 'object') return obj;
     if (obj instanceof Date) return new Date(obj.getTime());
@@ -148,7 +146,7 @@ const BAD_IRREVERSIBLE_OBJECTS = [
     },
 ] as any;
 
-const BAD_OBJECTS = [...new Set([...BAD_REVERSIBLE_OBJECTS, ...BAD_IRREVERSIBLE_OBJECTS])];
+const BAD_OBJECTS = [...BAD_REVERSIBLE_OBJECTS, ...BAD_IRREVERSIBLE_OBJECTS];
 
 // this effectively tests _escapePropertyName() and _unescapePropertyName()
 const KNOWN_ESCAPES: { irreversible?: boolean; src: any; trg: any }[] = [

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -1,6 +1,5 @@
 import * as http from 'node:http';
 
-import _ from 'underscore';
 import { describe, expect, it, vi } from 'vitest';
 
 import { makeInputJsFieldsReadable } from '@apify/input_schema';
@@ -57,7 +56,7 @@ describe('utilities', () => {
     });
 
     it('sequentializePromises()', async () => {
-        const range = _.range(21, 33);
+        const range = Array.from({ length: 12 }, (_, i) => 21 + i);
         const promises = range.map(async (index) => {
             return new Promise((resolve) => {
                 setTimeout(() => resolve(index), Math.round(Math.random() * 100));


### PR DESCRIPTION
Replaces six dev dependencies with platform natives: `strip-ansi` -> `node:util.stripVTControlCharacters`, `underscore` (+ types) -> `Array`/`Set` natives and two tiny test helpers, `clone-deep` (+ types) -> a small local clone function in the one test using it (`structuredClone` was not a fit: the fixtures contain functions and Buffers), and `rimraf` -> a two-line `fs.rmSync` script that the per-package `clean` scripts now run with plain node.

Test-and-build-time only, no published package changes. Stacked on the git-url-parse PR.
