### PR TITLE
ci: create annotated release tags so lerna detects changed packages

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -120,12 +120,20 @@ jobs:
 
             - name: Push tags via API to have them signed
               if: ${{ !inputs.prerelease }}
+              # Tags must be annotated (tag objects, not plain refs): lerna anchors "changed since"
+              # detection on `git describe`, which ignores lightweight tags, so plain refs make
+              # every release re-publish all packages.
               run: |
                   while IFS= read -r tag; do
                       [ -z "$tag" ] && continue
+                      tag_sha=$(gh api -X POST /repos/${{ github.repository }}/git/tags \
+                          -f tag="$tag" \
+                          -f message="$tag" \
+                          -f object="$COMMIT_SHA" \
+                          -f type=commit --jq .sha)
                       gh api -X POST /repos/${{ github.repository }}/git/refs \
                           -f ref="refs/tags/$tag" \
-                          -f sha="$COMMIT_SHA"
+                          -f sha="$tag_sha"
                   done <<< "$TAGS"
               env:
                   GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
Every stable release since June has re-published all packages. The "push tags via API" step creates lightweight tag refs, but lerna anchors its changed-package detection on `git describe`, which only sees annotated tags, so it kept anchoring on `@apify/input_schema@3.28.18` (the last annotated tag, from before the API push replaced lerna's own tagging) and treated everything as changed. This creates a tag object first and points the ref at it, making release tags annotated again. The lightweight tags on the latest release commit still need a one-off conversion, otherwise the next release anchors on the June tag one more time.