### PR TITLE
ci: create GitHub releases for stable versions again

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -62,7 +62,18 @@ jobs:
                       exit 1
                   fi
 
+            # A push that touches no package (workflow or docs changes) must skip the whole release:
+            # with nothing to version, lerna makes no commit and the reset/signed-commit steps below
+            # would mangle the checked-out commit instead.
+            - name: Check for changed packages
+              id: changed
+              run: |
+                  count=$(pnpm exec lerna changed -p 2>/dev/null | wc -l | xargs)
+                  echo "count=$count" | tee -a "$GITHUB_OUTPUT"
+                  if [ "$count" = "0" ]; then echo "No changed packages, nothing to release."; fi
+
             - name: Build module
+              if: ${{ steps.changed.outputs.count != '0' }}
               run: pnpm build
 
             # We publish in a few steps:
@@ -76,7 +87,7 @@ jobs:
             # prerelease number from the npm registry (see scripts/resolve-beta-versions.ts). The
             # local commit below is a throwaway lerna needs to see a clean tree; it is never pushed.
             - name: Version packages (beta prerelease)
-              if: ${{ inputs.prerelease }}
+              if: ${{ inputs.prerelease && steps.changed.outputs.count != '0' }}
               run: |
                   git checkout -- .
                   pnpm exec lerna version --conventional-prerelease --preid beta --no-push --no-git-tag-version --no-changelog --yes
@@ -84,7 +95,7 @@ jobs:
                   git -c user.name="Apify Release Bot" -c user.email="noreply@apify.com" commit -am "chore: beta versions [local only]"
 
             - name: Version packages
-              if: ${{ !inputs.prerelease }}
+              if: ${{ !inputs.prerelease && steps.changed.outputs.count != '0' }}
               id: version_packages
               run: |
                   git checkout -- .
@@ -105,13 +116,13 @@ jobs:
                   GIT_COMMITTER_EMAIL: "noreply@apify.com"
 
             - name: Sync root changelog
-              if: ${{ !inputs.prerelease }}
+              if: ${{ !inputs.prerelease && steps.changed.outputs.count != '0' }}
               run: |
                   pnpm install --no-frozen-lockfile # reinstall to have updated lock file
                   pnpm exec lerna ls --json | node scripts/sync-root-changelog.ts
 
             - name: Commit and push changes
-              if: ${{ !inputs.prerelease }}
+              if: ${{ !inputs.prerelease && steps.changed.outputs.count != '0' }}
               id: signed_commit
               uses: apify/actions/signed-commit@v1.4.0
               with:
@@ -119,7 +130,7 @@ jobs:
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Push tags via API to have them signed
-              if: ${{ !inputs.prerelease }}
+              if: ${{ !inputs.prerelease && steps.changed.outputs.count != '0' }}
               # Tags must be annotated (tag objects, not plain refs): lerna anchors "changed since"
               # detection on `git describe`, which ignores lightweight tags, so plain refs make
               # every release re-publish all packages.
@@ -141,11 +152,12 @@ jobs:
                   COMMIT_SHA: ${{ steps.signed_commit.outputs.commit_long_sha }}
 
             - name: Create GitHub releases
-              if: ${{ !inputs.prerelease }}
+              if: ${{ !inputs.prerelease && steps.changed.outputs.count != '0' }}
               run: node scripts/create-github-releases.ts
               env:
                   GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                   TAGS: ${{ steps.version_packages.outputs.tags }}
 
             - name: Publish to NPM
+              if: ${{ steps.changed.outputs.count != '0' }}
               run: pnpm exec lerna publish from-package --contents dist --yes ${{ inputs.prerelease && '--dist-tag next' || '' }}

--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -140,5 +140,12 @@ jobs:
                   TAGS: ${{ steps.version_packages.outputs.tags }}
                   COMMIT_SHA: ${{ steps.signed_commit.outputs.commit_long_sha }}
 
+            - name: Create GitHub releases
+              if: ${{ !inputs.prerelease }}
+              run: node scripts/create-github-releases.ts
+              env:
+                  GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                  TAGS: ${{ steps.version_packages.outputs.tags }}
+
             - name: Publish to NPM
               run: pnpm exec lerna publish from-package --contents dist --yes ${{ inputs.prerelease && '--dist-tag next' || '' }}

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,6 @@
         "version": {
             "conventionalCommits": true,
             "granularPathspec": false,
-            "createRelease": "github",
             "message": "chore: release [skip ci]"
         },
         "publish": {

--- a/scripts/create-github-releases.ts
+++ b/scripts/create-github-releases.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Creates a GitHub release for every tag produced by `lerna version`, with the matching section
+// of the package changelog as the body. Lerna's own `createRelease` is disabled by `--no-push`
+// (the release commit and tags are recreated signed via the API), so releases are made here.
+const tags = (process.env.TAGS ?? '').split('\n').map((t) => t.trim()).filter(Boolean);
+const packagesDir = resolve(import.meta.dirname, '..', 'packages');
+
+const dirByName = new Map<string, string>();
+for (const dir of readdirSync(packagesDir)) {
+    try {
+        const pkg = JSON.parse(readFileSync(resolve(packagesDir, dir, 'package.json'), 'utf8'));
+        dirByName.set(pkg.name, dir);
+    } catch {
+        // not a package directory
+    }
+}
+
+function changelogEntry(name: string, version: string): string {
+    const dir = dirByName.get(name);
+    if (!dir) return '';
+    let changelog = '';
+
+    try {
+        changelog = readFileSync(resolve(packagesDir, dir, 'CHANGELOG.md'), 'utf8');
+    } catch {
+        return '';
+    }
+
+    // Entries look like `# [3.0.0](compare-url) (date)` (major/minor) or `## [3.0.1](...)` (patch)
+    const escaped = version.replaceAll('.', '\\.');
+    const entry = new RegExp(`^#{1,2} \\[?${escaped}[\\]) ].*?(?=^#{1,2} \\[?\\d|$(?![\\s\\S]))`, 'ms').exec(changelog);
+    return entry ? entry[0].trim() : '';
+}
+
+let failures = 0;
+
+for (const tag of tags) {
+    const at = tag.lastIndexOf('@');
+    const name = tag.slice(0, at);
+    const version = tag.slice(at + 1);
+    const body = changelogEntry(name, version) || `Release ${tag}`;
+
+    try {
+        execFileSync('gh', ['release', 'view', tag], { stdio: 'ignore' });
+        console.info(`${tag}: release already exists, skipping`);
+        continue;
+    } catch {
+        // no release yet
+    }
+
+    try {
+        execFileSync('gh', ['release', 'create', tag, '--title', tag, '--notes', body], { stdio: 'inherit' });
+        console.info(`${tag}: release created`);
+    } catch {
+        console.error(`${tag}: failed to create the release`);
+        failures++;
+    }
+}
+
+if (failures > 0) process.exit(1);

--- a/scripts/create-github-releases.ts
+++ b/scripts/create-github-releases.ts
@@ -6,7 +6,10 @@ import { resolve } from 'node:path';
 // Creates a GitHub release for every tag produced by `lerna version`, with the matching section
 // of the package changelog as the body. Lerna's own `createRelease` is disabled by `--no-push`
 // (the release commit and tags are recreated signed via the API), so releases are made here.
-const tags = (process.env.TAGS ?? '').split('\n').map((t) => t.trim()).filter(Boolean);
+const tags = (process.env.TAGS ?? '')
+    .split('\n')
+    .map((t) => t.trim())
+    .filter(Boolean);
 const packagesDir = resolve(import.meta.dirname, '..', 'packages');
 
 const dirByName = new Map<string, string>();


### PR DESCRIPTION
GitHub releases have not been created since June: lerna's `createRelease: "github"` only runs on its push path, which the signed-commit flow disables with `--no-push` (lerna logs "Skipping releases"). This adds a workflow step that creates a release for each tag from `lerna version`, using the matching package changelog section as the body, and drops the dead `createRelease` config from lerna.json. Betas are unaffected (the step is gated on `!inputs.prerelease`, and the beta path produces no tags anyway). The step is idempotent, so a re-dispatched publish run skips releases that already exist.
Also guards the whole release on `lerna changed`: a push that touches no package (like this one, or #701) used to be masked by the lightweight-tag bug, but with detection fixed, `lerna version` would create no commit and the unconditional reset + signed-commit steps would push a bogus release commit. Now such runs report "nothing to release" and skip everything.
